### PR TITLE
Bump http4s version to 0.22

### DIFF
--- a/modules/http4s/src/main/scala/com/evolutiongaming/smetrics/Http4sMetricsOps.scala
+++ b/modules/http4s/src/main/scala/com/evolutiongaming/smetrics/Http4sMetricsOps.scala
@@ -4,7 +4,7 @@ import cats.Monad
 import cats.effect._
 import cats.syntax.all._
 import com.evolutiongaming.smetrics.MetricsHelper._
-import org.http4s.metrics.TerminationType.{Abnormal, Error, Timeout}
+import org.http4s.metrics.TerminationType.{Abnormal, Canceled, Error, Timeout}
 import org.http4s.metrics.{MetricsOps, TerminationType}
 import org.http4s.{Method, Status}
 
@@ -99,9 +99,10 @@ object Http4sMetricsOps {
   }
 
   private def reportTermination(t: TerminationType): String = t match {
-    case Abnormal => "abnormal"
-    case Error    => "error"
-    case Timeout  => "timeout"
+    case Abnormal(_) => "abnormal"
+    case Error(_)    => "error"
+    case Timeout     => "timeout"
+    case Canceled    => "canceled"
   }
 
   private def reportPhase(p: Phase): String = p match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,12 +2,12 @@ import sbt._
 
 object Dependencies {
 
-  private val prometheusVersion = "0.8.1"
+  private val prometheusVersion = "0.9.0"
   val prometheus       = "io.prometheus"        % "simpleclient"        % prometheusVersion
   val prometheusCommon = "io.prometheus"        % "simpleclient_common" % prometheusVersion
   val scalatest        = "org.scalatest"       %% "scalatest"           % "3.2.9"
-  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "2.2.3"
-  val http4s           = "org.http4s"          %% "http4s-core"         % "0.21.22"
+  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "2.6.2"
+  val http4s           = "org.http4s"          %% "http4s-core"         % "0.22.7"
   val doobie           = "org.tpolecat"        %% "doobie-core"         % "0.9.0"
 
   object Cats {


### PR DESCRIPTION
smetrics produce errors when using with http4s-0.22 as 0.21 and 0.22 are binary-incompatible