### PR TITLE
migrate to sbt-ci-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,38 +1,49 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["master"]
+    tags: ["v*"]
+  pull_request:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         scala:
-          - 3.2.0
-          - 2.13.8
-          - 2.12.16
+          - 2.13.11
+          - 3.3.0
+          - 2.12.18
 
     steps:
       - uses: actions/checkout@v3
 
       - uses: coursier/cache-action@v6
 
-      - name: scala
-        uses: olafurpg/setup-scala@v11
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: "17"
+          distribution: "temurin"
+          cache: "sbt"
 
       - name: build ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} clean coverage test
 
-      - name: test coverageReport coverageAggregate coveralls
+      - name: test coverage
         if: success()
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: sbt ++${{ matrix.scala }} coverageAggregate coveralls
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
+        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
 
       - name: slack
         uses: homoluctus/slatify@master
@@ -41,3 +52,29 @@ jobs:
           type: ${{ job.status }}
           job_name: Build
           url: ${{ secrets.SLACK_WEBHOOK }}
+
+
+  publish:
+    name: Publish Artifacts
+    needs: [test]
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: coursier/cache-action@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: "sbt"
+
+      - name: Publish artifacts
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASS }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: sbt ci-release

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/evolution-gaming/smetrics/workflows/CI/badge.svg)](https://github.com/evolution-gaming/smetrics/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/evolution-gaming/smetrics/badge.svg)](https://coveralls.io/r/evolution-gaming/smetrics)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/04fb0fd38072413cb032d8a5e7c9def5)](https://www.codacy.com/app/evolution-gaming/smetrics?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=evolution-gaming/smetrics&amp;utm_campaign=Badge_Grade)
-[![Version](https://img.shields.io/badge/version-click-blue)](https://evolution.jfrog.io/artifactory/api/search/latestVersion?g=com.evolutiongaming&a=smetrics_2.13&repos=public)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.evolution/smetrics.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.evolution/smetrics_2.13)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellowgreen.svg)](https://opensource.org/licenses/MIT)
 
 ## Features:

--- a/build.sbt
+++ b/build.sbt
@@ -1,67 +1,68 @@
 import sbt.librarymanagement.For3Use2_13
 import Dependencies._
 
-def crossSettings[T](scalaVersion: String, if3: Seq[T], if2: Seq[T]) = {
-  CrossVersion.partialVersion(scalaVersion) match {
-    case Some((3, _)) => if3
-    case Some((2, 12 | 13)) => if2
-    case _ => Nil
-  }
+def crossSettings[T](scalaVersion: String, if3: List[T] = Nil, if2: List[T] = Nil) = scalaVersion match {
+  case version if version.startsWith("3") => if3
+  case _                                  => if2
 }
 
-def is3(scalaVersion: String): Boolean = scalaVersion.startsWith("3")
-
 lazy val commonSettings = Seq(
-  organization := "com.evolutiongaming",
-  homepage := Some(new URL("http://github.com/evolution-gaming/smetrics")),
-  startYear := Some(2019),
+  homepage := Some(new URL("http://github.com/evolution-gaming/cats-helper")),
+  organization := "com.evolution",
   organizationName := "Evolution",
   organizationHomepage := Some(url("http://evolution.com")),
-  scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := Seq("2.13.8", "3.2.0", "2.12.16"),
-  publishTo := Some(Resolver.evolutionReleases),
+
+  startYear := Some(2019),
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
-  releaseCrossBuild := true,
-  Compile / doc / scalacOptions += "-no-link-warnings")
 
+  versionScheme := Some("semver-spec"),
+  crossScalaVersions := Seq("2.13.11", "3.3.0", "2.12.18"),
+  scalaVersion := crossScalaVersions.value.head,
 
-lazy val root = (project
-  in file(".")
-  settings commonSettings
-  settings (
+  sonatypeCredentialHost := "s01.oss.sonatype.org",
+  sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
+
+  scmInfo := Some(
+    ScmInfo(
+      url("https://github.com/evolution-gaming/smetrics"),
+      "git@github.com:evolution-gaming/smetrics.git"
+    )
+  ),
+  Test / publishArtifact := false,
+  Compile / doc / scalacOptions += "-no-link-warnings"
+)
+
+lazy val root = project
+  .in(file("."))
+  .settings(commonSettings)
+  .settings(
     publish / skip := true,
     name := "smetrics-parent"
   )
-  aggregate(smetrics, prometheus, http4s, doobie))
+  .aggregate(smetrics, prometheus, http4s, doobie)
 
-lazy val smetrics = (project
-  in file("smetrics")
-  settings commonSettings
-  settings(
+lazy val smetrics = project
+  .in(file("smetrics"))
+  .settings(commonSettings)
+  .settings(
     name := "smetrics",
-    scalacOptsFailOnWarn := Some(false),
-    libraryDependencies ++= Seq(
-      Cats.core,
-      Cats.effect,
-      `cats-helper` % Test,
-      scalatest % Test),
+    libraryDependencies ++= Seq(Cats.core, Cats.effect, `cats-helper` % Test, scalatest % Test),
     libraryDependencies ++= crossSettings(
       scalaVersion.value,
-      if3 = Nil,
       if2 = List(compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full))
     ),
     scalacOptions ++= crossSettings(
       scalaVersion.value,
-      if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions"),
-      if2 = Seq("-Xsource:3", "-P:kind-projector:underscore-placeholders")
+      if3 = List("-Ykind-projector:underscores", "-language:implicitConversions"),
+      if2 = List("-Xsource:3", "-P:kind-projector:underscore-placeholders")
     )
-))
+  )
 
-lazy val prometheus = (project
-  in file("modules/prometheus")
-  settings commonSettings
-  dependsOn smetrics % "compile->compile;test->test"
-  settings (
+lazy val prometheus = project
+  .in(file("modules/prometheus"))
+  .settings(commonSettings)
+  .dependsOn(smetrics % "compile->compile;test->test")
+  .settings(
     name := "smetrics-prometheus",
     libraryDependencies ++= Seq(
       Dependencies.prometheus,
@@ -69,27 +70,22 @@ lazy val prometheus = (project
       scalatest % Test
     )
   )
-)
 
-lazy val http4s = (project
-  in file("modules/http4s")
-  settings commonSettings
-  dependsOn smetrics % "compile->compile;test->test"
-  settings(
+lazy val http4s = project
+  .in(file("modules/http4s"))
+  .settings(commonSettings)
+  .dependsOn(smetrics % "compile->compile;test->test")
+  .settings(
     name := "smetrics-http4s",
     libraryDependencies += Dependencies.http4s
   )
-)
 
-lazy val doobie = (project
-  in file("modules/doobie")
-  settings commonSettings
-  dependsOn smetrics % "compile->compile;test->test"
-  settings(
+lazy val doobie = project
+  .in(file("modules/doobie"))
+  .settings(commonSettings)
+  .dependsOn(smetrics % "compile->compile;test->test")
+  .settings(
     name := "smetrics-doobie",
     libraryDependencies += Dependencies.doobie,
-  libraryDependencies ++= Seq(
-    Dependencies.doobie,
-    `cats-helper`)
+    libraryDependencies ++= Seq(Dependencies.doobie, `cats-helper`)
   )
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.6")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "2.0.1-SNAPSHOT"


### PR DESCRIPTION
adapted from: https://github.com/evolution-gaming/scache/pull/164
part of: https://github.com/evolution-gaming/scache/issues/163

needs: https://github.com/evolution-gaming/cats-helper/pull/227

TODO in this PR:
- [ ] update dependency on [cats-helper](https://github.com/evolution-gaming/cats-helper) after https://github.com/evolution-gaming/cats-helper/pull/227 is merged
- [ ] rename packages to com.evolution to be consistent with new organization name
- [ ] take care of stale coverage badges?