### PR TITLE
Implement cached CollectorRegistry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val smetrics = (project
     libraryDependencies ++= Seq(
       Cats.core,
       Cats.effect,
-      `cats-helper` % Test,
+      `cats-helper`,
       scalatest % Test),
     libraryDependencies ++= crossSettings(
       scalaVersion.value,

--- a/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
+++ b/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
@@ -25,7 +25,7 @@ object Prometheus { prometheus =>
 
   def cached[F[_] : Async](javaRegistry: P.CollectorRegistry): Resource[F, Prometheus[F]] =
     for {
-      cachedRegistry <- CollectorRegistryPrometheus(javaRegistry).cached
+      cachedRegistry <- CollectorRegistryPrometheus(javaRegistry).withCaching
     } yield new Prometheus[F] {
 
       override val registry: CollectorRegistry[F] = cachedRegistry

--- a/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
+++ b/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
@@ -1,8 +1,8 @@
 package com.evolutiongaming.smetrics
 
+import cats.effect.kernel.Resource
 import java.io.StringWriter
-
-import cats.effect.Sync
+import cats.effect.{Async, Sync}
 import io.prometheus.client.exporter.common.TextFormat
 import io.prometheus.{client => P}
 
@@ -13,19 +13,32 @@ trait Prometheus[F[_]] {
   def write004: F[String]
 }
 
-object Prometheus {
+object Prometheus { prometheus =>
 
   def apply[F[_] : Sync](collectorRegistry: P.CollectorRegistry): Prometheus[F] =
     new Prometheus[F] {
 
       override val registry: CollectorRegistry[F] = CollectorRegistryPrometheus(collectorRegistry)
 
-      override val write004: F[String] = Sync[F].delay {
-        val writer = new StringWriter
-        TextFormat.write004(writer, collectorRegistry.metricFamilySamples)
-        writer.toString
-      }
+      override val write004: F[String] = prometheus.write004[F](collectorRegistry)
+    }
+
+  def cached[F[_] : Async](javaRegistry: P.CollectorRegistry): Resource[F, Prometheus[F]] =
+    for {
+      cachedRegistry <- CollectorRegistryPrometheus(javaRegistry).cached
+    } yield new Prometheus[F] {
+
+      override val registry: CollectorRegistry[F] = cachedRegistry
+
+      override val write004: F[String] = prometheus.write004[F](javaRegistry)
     }
 
   def default[F[_] : Sync]: Prometheus[F] = apply(P.CollectorRegistry.defaultRegistry)
+
+  private def write004[F[_] : Sync](registry: P.CollectorRegistry): F[String] = Sync[F].delay {
+    val writer = new StringWriter
+    TextFormat.write004(writer, registry.metricFamilySamples)
+    writer.toString
+  }
+
 }

--- a/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
+++ b/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
@@ -1,8 +1,8 @@
 package com.evolutiongaming.smetrics
 
-import cats.effect.kernel.Resource
 import java.io.StringWriter
 import cats.effect.{Async, Sync}
+import cats.syntax.all._
 import io.prometheus.client.exporter.common.TextFormat
 import io.prometheus.{client => P}
 
@@ -23,7 +23,7 @@ object Prometheus { prometheus =>
       override val write004: F[String] = prometheus.write004[F](collectorRegistry)
     }
 
-  def cached[F[_] : Async](javaRegistry: P.CollectorRegistry): Resource[F, Prometheus[F]] =
+  def cached[F[_] : Async](javaRegistry: P.CollectorRegistry): F[Prometheus[F]] =
     for {
       cachedRegistry <- CollectorRegistryPrometheus(javaRegistry).withCaching
     } yield new Prometheus[F] {

--- a/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedSpec.scala
+++ b/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedSpec.scala
@@ -5,7 +5,6 @@ import cats.effect.{Deferred, IO}
 import cats.effect.implicits.effectResourceOps
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.SerialRef
-import io.prometheus.client.{CollectorRegistry => JavaRegistry}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -17,7 +16,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple gauges with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry).toResource
+        pr <- Prometheus.default[IO].withCaching.toResource
         g1 <- pr.registry.gauge("foo", "bar", LabelNames("baz"))
         g2 <- pr.registry.gauge("foo", "bar", LabelNames("baz"))
       } yield (pr, g1, g2)
@@ -41,7 +40,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple gauges with same name but different labels" in {
       val res = for {
-        p <- Prometheus.cached[IO](JavaRegistry.defaultRegistry).toResource
+        p <- Prometheus.default[IO].withCaching.toResource
         _ <- p.registry.gauge("foo", "bar", LabelNames("baz"))
         _ <- p.registry.gauge("foo", "bar", LabelNames("ams"))
       } yield {}
@@ -56,7 +55,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create gauge and then counter with same name" in {
       val res = for {
-        p <- Prometheus.cached[IO](JavaRegistry.defaultRegistry).toResource
+        p <- Prometheus.default[IO].withCaching.toResource
         _ <- p.registry.gauge("foo", "bar", LabelNames("baz"))
         _ <- p.registry.counter("foo", "bar", LabelNames("ams"))
       } yield {}
@@ -131,7 +130,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple counters with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry).toResource
+        pr <- Prometheus.default[IO].withCaching.toResource
         c1 <- pr.registry.counter("foo", "bar", LabelNames("baz"))
         c2 <- pr.registry.counter("foo", "bar", LabelNames("baz"))
       } yield (pr, c1, c2)
@@ -155,7 +154,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple summaries with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry).toResource
+        pr <- Prometheus.default[IO].withCaching.toResource
         s1 <- pr.registry.summary(
           "foo",
           "bar",
@@ -191,7 +190,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple histograms with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry).toResource
+        pr <- Prometheus.default[IO].withCaching.toResource
         h1 <- pr.registry.histogram(
           "foo",
           "bar",

--- a/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedSpec.scala
+++ b/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedSpec.scala
@@ -1,0 +1,172 @@
+package com.evolutiongaming.smetrics
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import com.evolutiongaming.smetrics.CollectorRegistry.CachedRegistryException
+import io.prometheus.client.CollectorRegistry
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
+
+  "cached collector registry" should {
+
+    import cats.effect.unsafe.implicits.global
+
+    "create multiple gauges with same name" in {
+      val res = for {
+        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        g1 <- pr.registry.gauge("foo", "bar", LabelNames("baz"))
+        g2 <- pr.registry.gauge("foo", "bar", LabelNames("baz"))
+      } yield (pr, g1, g2)
+      res
+        .use {
+          case (pr, g1, g2) =>
+            for {
+              _ <- g1.labels("foo").inc()
+              _ <- g2.labels("bar").inc()
+              r <- pr.write004
+            } yield
+              r shouldBe
+                """# HELP foo bar
+                  |# TYPE foo gauge
+                  |foo{baz="bar",} 1.0
+                  |foo{baz="foo",} 1.0
+                  |""".stripMargin
+        }
+        .unsafeRunSync()
+    }
+
+    "create multiple gauges with same name but different labels" in {
+      val res = for {
+        p <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        _ <- p.registry.gauge("foo", "bar", LabelNames("baz"))
+        _ <- p.registry.gauge("foo", "bar", LabelNames("ams"))
+      } yield {}
+      try {
+        res.use_.unsafeRunSync()
+        fail("the test must throw CachedRegistryException")
+      } catch {
+        case e: CachedRegistryException =>
+          e.getMessage shouldBe "metric `foo` of type `gauge` with labels [baz] already registered, while new metric tried to be created with labels [ams]"
+      }
+    }
+
+    "create gauge and then counter with same name" in {
+      val res = for {
+        p <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        _ <- p.registry.gauge("foo", "bar", LabelNames("baz"))
+        _ <- p.registry.counter("foo", "bar", LabelNames("ams"))
+      } yield {}
+      try {
+        res.use_.unsafeRunSync()
+        fail("the test must throw CachedRegistryException")
+      } catch {
+        case e: CachedRegistryException =>
+          e.getMessage shouldBe "metric `foo` of type `gauge` with labels [baz] already registered, while new metric of type `counter` tried to be created"
+      }
+    }
+
+    "create multiple counters with same name" in {
+      val res = for {
+        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        c1 <- pr.registry.counter("foo", "bar", LabelNames("baz"))
+        c2 <- pr.registry.counter("foo", "bar", LabelNames("baz"))
+      } yield (pr, c1, c2)
+      res
+        .use {
+          case (pr, c1, c2) =>
+            for {
+              _ <- c1.labels("foo").inc()
+              _ <- c2.labels("bar").inc()
+              r <- pr.write004
+            } yield
+              r shouldBe
+                """# HELP foo bar
+                   |# TYPE foo counter
+                   |foo{baz="bar",} 1.0
+                   |foo{baz="foo",} 1.0
+                   |""".stripMargin
+        }
+        .unsafeRunSync()
+    }
+
+    "create multiple summaries with same name" in {
+      val res = for {
+        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        s1 <- pr.registry.summary(
+          "foo",
+          "bar",
+          Quantiles.Empty,
+          LabelNames("baz")
+        )
+        s2 <- pr.registry.summary(
+          "foo",
+          "bar",
+          Quantiles.Empty,
+          LabelNames("baz")
+        )
+      } yield (pr, s1, s2)
+      res
+        .use {
+          case (pr, s1, s2) =>
+            for {
+              _ <- s1.labels("foo").observe(42d)
+              _ <- s2.labels("bar").observe(42d)
+              r <- pr.write004
+            } yield
+              r shouldBe
+                """# HELP foo bar
+                  |# TYPE foo summary
+                  |foo_count{baz="bar",} 1.0
+                  |foo_sum{baz="bar",} 42.0
+                  |foo_count{baz="foo",} 1.0
+                  |foo_sum{baz="foo",} 42.0
+                  |""".stripMargin
+        }
+        .unsafeRunSync()
+    }
+
+    "create multiple histograms with same name" in {
+      val res = for {
+        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        h1 <- pr.registry.histogram(
+          "foo",
+          "bar",
+          Buckets(NonEmptyList.one(42d)),
+          LabelNames("baz")
+        )
+        h2 <- pr.registry.histogram(
+          "foo",
+          "bar",
+          Buckets(NonEmptyList.one(42d)),
+          LabelNames("baz")
+        )
+      } yield (pr, h1, h2)
+      res
+        .use {
+          case (pr, h1, h2) =>
+            for {
+              _ <- h1.labels("foo").observe(42d)
+              _ <- h2.labels("bar").observe(42d)
+              r <- pr.write004
+            } yield
+              r shouldBe
+                """# HELP foo bar
+                  |# TYPE foo histogram
+                  |foo_bucket{baz="bar",le="42.0",} 1.0
+                  |foo_bucket{baz="bar",le="+Inf",} 1.0
+                  |foo_count{baz="bar",} 1.0
+                  |foo_sum{baz="bar",} 42.0
+                  |foo_bucket{baz="foo",le="42.0",} 1.0
+                  |foo_bucket{baz="foo",le="+Inf",} 1.0
+                  |foo_count{baz="foo",} 1.0
+                  |foo_sum{baz="foo",} 42.0
+                  |""".stripMargin
+        }
+        .unsafeRunSync()
+    }
+
+  }
+
+}

--- a/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedSpec.scala
+++ b/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedSpec.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.smetrics
 import cats.data.NonEmptyList
 import cats.effect.IO
 import com.evolutiongaming.smetrics.CollectorRegistry.CachedRegistryException
-import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.{ CollectorRegistry => JavaRegistry }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -15,7 +15,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple gauges with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry)
         g1 <- pr.registry.gauge("foo", "bar", LabelNames("baz"))
         g2 <- pr.registry.gauge("foo", "bar", LabelNames("baz"))
       } yield (pr, g1, g2)
@@ -39,7 +39,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple gauges with same name but different labels" in {
       val res = for {
-        p <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        p <- Prometheus.cached[IO](JavaRegistry.defaultRegistry)
         _ <- p.registry.gauge("foo", "bar", LabelNames("baz"))
         _ <- p.registry.gauge("foo", "bar", LabelNames("ams"))
       } yield {}
@@ -54,7 +54,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create gauge and then counter with same name" in {
       val res = for {
-        p <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        p <- Prometheus.cached[IO](JavaRegistry.defaultRegistry)
         _ <- p.registry.gauge("foo", "bar", LabelNames("baz"))
         _ <- p.registry.counter("foo", "bar", LabelNames("ams"))
       } yield {}
@@ -69,7 +69,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple counters with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry)
         c1 <- pr.registry.counter("foo", "bar", LabelNames("baz"))
         c2 <- pr.registry.counter("foo", "bar", LabelNames("baz"))
       } yield (pr, c1, c2)
@@ -93,7 +93,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple summaries with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry)
         s1 <- pr.registry.summary(
           "foo",
           "bar",
@@ -129,7 +129,7 @@ class CollectorRegistryCachedSpec extends AnyWordSpec with Matchers {
 
     "create multiple histograms with same name" in {
       val res = for {
-        pr <- Prometheus.cached[IO](CollectorRegistry.defaultRegistry)
+        pr <- Prometheus.cached[IO](JavaRegistry.defaultRegistry)
         h1 <- pr.registry.histogram(
           "foo",
           "bar",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val prometheus       = "io.prometheus"        % "simpleclient"        % prometheusVersion
   val prometheusCommon = "io.prometheus"        % "simpleclient_common" % prometheusVersion
   val scalatest        = "org.scalatest"       %% "scalatest"           % "3.2.15"
-  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "3.6.1-SNAPSHOT"
+  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "3.7.0"
   val http4s           = "org.http4s"          %% "http4s-core"         % "0.23.7"
   val doobie           = "org.tpolecat"        %% "doobie-core"         % "1.0.0-RC2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val prometheus       = "io.prometheus"        % "simpleclient"        % prometheusVersion
   val prometheusCommon = "io.prometheus"        % "simpleclient_common" % prometheusVersion
   val scalatest        = "org.scalatest"       %% "scalatest"           % "3.2.15"
-  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "3.5.0"
+  val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "3.6.1-SNAPSHOT"
   val http4s           = "org.http4s"          %% "http4s-core"         % "0.23.7"
   val doobie           = "org.tpolecat"        %% "doobie-core"         % "1.0.0-RC2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val prometheusCommon = "io.prometheus"        % "simpleclient_common" % prometheusVersion
   val scalatest        = "org.scalatest"       %% "scalatest"           % "3.2.15"
   val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "3.5.0"
-  val http4s           = "org.http4s"          %% "http4s-core"         % "0.23.18"
+  val http4s           = "org.http4s"          %% "http4s-core"         % "0.23.7"
   val doobie           = "org.tpolecat"        %% "doobie-core"         % "1.0.0-RC2"
 
   object Cats {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,13 +1,13 @@
-import sbt._
+import sbt.*
 
 object Dependencies {
 
   private val prometheusVersion = "0.9.0"
   val prometheus       = "io.prometheus"        % "simpleclient"        % prometheusVersion
   val prometheusCommon = "io.prometheus"        % "simpleclient_common" % prometheusVersion
-  val scalatest        = "org.scalatest"       %% "scalatest"           % "3.2.13"
+  val scalatest        = "org.scalatest"       %% "scalatest"           % "3.2.15"
   val `cats-helper`    = "com.evolutiongaming" %% "cats-helper"         % "3.5.0"
-  val http4s           = "org.http4s"          %% "http4s-core"         % "0.23.7"
+  val http4s           = "org.http4s"          %% "http4s-core"         % "0.23.18"
   val doobie           = "org.tpolecat"        %% "doobie-core"         % "1.0.0-RC2"
 
   object Cats {

--- a/smetrics/src/main/scala/com/evolutiongaming/smetrics/CollectorRegistry.scala
+++ b/smetrics/src/main/scala/com/evolutiongaming/smetrics/CollectorRegistry.scala
@@ -7,8 +7,6 @@ import cats.effect.implicits.effectResourceOps
 import cats.implicits.*
 import com.evolutiongaming.catshelper.SerialRef
 
-import scala.util.control.NoStackTrace
-
 trait CollectorRegistry[F[_]] {
 
   def gauge[A, B[_]](
@@ -367,7 +365,7 @@ object CollectorRegistry {
                   .catchNonFatal {
                     entry.collector.asInstanceOf[A]
                   }
-                  .recoverWith { cause =>
+                  .recoverWith { case cause =>
                     val message =
                       s"metric `$name` of type `${entry.ofType}` with labels [${entry.names.mkString(", ")}] " +
                         s"already registered and cannot be cast to type `$ofType` with labels [${names.mkString(", ")}]"

--- a/smetrics/src/main/scala/com/evolutiongaming/smetrics/CollectorRegistry.scala
+++ b/smetrics/src/main/scala/com/evolutiongaming/smetrics/CollectorRegistry.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.smetrics
 
 import cats.Monad
-import cats.effect.{Concurrent, Ref, Resource}
+import cats.effect.{Concurrent, Resource}
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{ResourceCounter, SerialRef}


### PR DESCRIPTION
Motivation:

implement caching layer on top of `CollectorRegistry` to overcome limitations of java's`CollectorRegistry`, ie throwing exceptions on registering same metric multiple times 