### PR TITLE
bulk libs update

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,24 +5,24 @@ object Dependencies {
   private val prometheusVersion = "0.9.0"
   val prometheus = "io.prometheus" % "simpleclient" % prometheusVersion
   val prometheusCommon = "io.prometheus" % "simpleclient_common" % prometheusVersion
-  val scalatest = "org.scalatest" %% "scalatest" % "3.2.19"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.2.20"
   val `cats-helper` = "com.evolutiongaming" %% "cats-helper" % "3.12.2"
-  val http4s = "org.http4s" %% "http4s-core" % "0.23.33"
+  val http4s = "org.http4s" %% "http4s-core" % "0.23.36"
   val doobie = "org.tpolecat" %% "doobie-core" % "1.0.0-RC11"
 
   object Cats {
     val core = "org.typelevel" %% "cats-core" % "2.13.0"
-    val effect = "org.typelevel" %% "cats-effect" % "3.6.3"
+    val effect = "org.typelevel" %% "cats-effect" % "3.7.0"
   }
 
   object PrometheusV1 {
-    private val version = "1.4.3"
+    private val version = "1.8.0"
     val core = "io.prometheus" % "prometheus-metrics-core" % version
     val formats = "io.prometheus" % "prometheus-metrics-exposition-textformats" % version
   }
 
   object Logback {
-    private val version = "1.5.22"
+    private val version = "1.5.38"
     val classic = "ch.qos.logback" % "logback-classic" % version
   }
 
@@ -33,7 +33,7 @@ object Dependencies {
   }
 
   object Sttp4 {
-    private val version = "4.0.13"
+    private val version = "4.0.26"
     val core = "com.softwaremill.sttp.client4" %% "core" % version
     val catsBackend = "com.softwaremill.sttp.client4" %% "cats" % version
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.2
+sbt.version=1.12.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,10 +4,10 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.3.0")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")


### PR DESCRIPTION
Bulk dependency update.

**Updated:**

- ch.epfl.scala:sbt-version-policy: 3.2.1 → 3.3.0
- ch.qos.logback:logback-classic: 1.5.22 → 1.5.38
- com.softwaremill.sttp.client4:core, cats: 4.0.13 → 4.0.26
- io.prometheus:prometheus-metrics-core, prometheus-metrics-exposition-textformats: 1.4.3 → 1.8.0
- org.http4s:http4s-core: 0.23.33 → 0.23.36
- org.scalameta:sbt-scalafmt: 2.5.6 → 2.6.1
- org.scalatest:scalatest: 3.2.19 → 3.2.20
- org.typelevel:cats-effect: 3.6.3 → 3.7.0
- sbt: 1.12.2 → 1.12.13

**Skipped:**

- org.sbt:sbt: 1.12.2 → 2.0.2 (sbt 2.0.2 requires sbt-2 plugin builds; com.evolution:sbt-scalac-opts-plugin, com.evolution:sbt-artifactory-plugin and org.scoverage:sbt-coveralls publish no _sbt2_3 artifacts (verified: project fails to load). Bumped to latest 1.x (1.12.13) instead.)
- org.tpolecat:doobie-core: 1.0.0-RC11 → 0.13.4 (latest stable (0.13.4) is older than the 1.0.0-RC11 already in use; no downgrade)
- com.evolution:sbt-scalac-opts-plugin: 0.0.9 → 0.0.8 (resolution table suggests an older version than the one in use; no downgrade)
- io.prometheus:simpleclient: 0.9.0 → 0.16.0 (0.10+ switches to the OpenMetrics data model (counters exposed as <name>_total plus <name>_created series), a breaking change in exposition format for library consumers)
- io.prometheus:simpleclient_common: 0.9.0 → 0.16.0 (kept in lockstep with io.prometheus:simpleclient (see above))

**Notable changes:**

- cats-effect 3.6.3 → 3.7.0 — fully binary-compatible with 3.x; headline change is Scala Native 0.5 support with full multithreading
- sbt kept on 1.x (bumped 1.12.2 → 1.12.13): sbt 2.0.2 requires sbt-2 plugin builds that sbt-scalac-opts-plugin, sbt-artifactory-plugin and sbt-coveralls do not publish

<details><summary><b>Changelogs</b></summary>

<details><summary><b>ch.epfl.scala:sbt-version-policy</b> 3.2.1 → 3.3.0</summary>

> No changelog available — POM not found

</details>

<details><summary><b>ch.qos.logback:logback-classic</b> 1.5.22 → 1.5.38</summary>

> No changelog available — no GitHub source in POM

</details>

<details><summary><b>com.softwaremill.sttp.client4:cats</b> 4.0.13 → 4.0.26 &nbsp;·&nbsp; <a href="https://github.com/softwaremill/sttp/releases">releases</a></summary>

</details>

<details><summary><b>com.softwaremill.sttp.client4:core</b> 4.0.13 → 4.0.26 &nbsp;·&nbsp; <a href="https://github.com/softwaremill/sttp/releases">releases</a></summary>

</details>

<details><summary><b>io.prometheus:prometheus-metrics-core</b> 1.4.3 → 1.8.0</summary>

> No changelog available — no GitHub source in POM

</details>

<details><summary><b>io.prometheus:prometheus-metrics-exposition-textformats</b> 1.4.3 → 1.8.0</summary>

> No changelog available — no GitHub source in POM

</details>

<details><summary><b>org.http4s:http4s-core</b> 0.23.33 → 0.23.36 &nbsp;·&nbsp; <a href="https://github.com/http4s/http4s/releases">releases</a></summary>

</details>

<details><summary><b>org.scalameta:sbt-scalafmt</b> 2.5.6 → 2.6.1</summary>

> No changelog available — POM not found

</details>

<details><summary><b>org.scalatest:scalatest</b> 3.2.19 → 3.2.20</summary>

> No changelog available — no GitHub releases tagged in (3.2.19, 3.2.20]

</details>

<details><summary><b>org.typelevel:cats-effect</b> 3.6.3 → 3.7.0 &nbsp;·&nbsp; <a href="https://github.com/typelevel/cats-effect/releases">releases</a></summary>

</details>

</details>