### PR TITLE
With cache registry fix

### DIFF
--- a/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedInitializedSpec.scala
+++ b/modules/prometheus/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedInitializedSpec.scala
@@ -1,0 +1,68 @@
+package com.evolutiongaming.smetrics
+
+import cats.data.NonEmptyList as Nel
+import cats.effect.{IO, Resource}
+import cats.syntax.all.*
+import io.prometheus.client as P
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** Caching a registry must not change initialization semantics: the `*Initialized` variants have to pre-create the
+  * time series for every combination of label values, so that they are exposed on scrape before the first observation.
+  */
+class CollectorRegistryCachedInitializedSpec extends AnyWordSpec with Matchers {
+
+  import cats.effect.unsafe.implicits.global
+
+  private val labels = LabelsInitialized("baz", Nel.of("v1", "v2"))
+
+  "cached collector registry" should {
+
+    "pre-create label values for gaugeInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.gaugeInitialized("foo", "bar", labels)
+      }
+    }
+
+    "pre-create label values for counterInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.counterInitialized("foo", "bar", labels)
+      }
+    }
+
+    "pre-create label values for summaryInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.summaryInitialized("foo", "bar", Quantiles.Empty, labels)
+      }
+    }
+
+    "pre-create label values for histogramInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.histogramInitialized("foo", "bar", Buckets(Nel.one(42d)), labels)
+      }
+    }
+  }
+
+  private def verifyCachingPreservesInitialization(
+    createMetric: CollectorRegistry[IO] => Resource[IO, Any],
+  ): Assertion = {
+    val expected = scrape(caching = false, createMetric)
+    val actual = scrape(caching = true, createMetric)
+
+    expected should include("""baz="v1"""")
+    actual shouldBe expected
+  }
+
+  private def scrape(
+    caching: Boolean,
+    createMetric: CollectorRegistry[IO] => Resource[IO, Any],
+  ): String = {
+    val prometheus = Prometheus[IO](new P.CollectorRegistry())
+    val res = for {
+      prometheus <- if (caching) prometheus.withCaching.toResource else prometheus.pure[IO].toResource
+      _ <- createMetric(prometheus.registry)
+    } yield prometheus
+    res.use(_.write004).unsafeRunSync()
+  }
+}

--- a/modules/prometheus_v1/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedInitializedSpec.scala
+++ b/modules/prometheus_v1/src/test/scala/com/evolutiongaming/smetrics/CollectorRegistryCachedInitializedSpec.scala
@@ -1,0 +1,68 @@
+package com.evolutiongaming.smetrics
+
+import cats.data.NonEmptyList as Nel
+import cats.effect.{IO, Resource}
+import cats.syntax.all.*
+import io.prometheus.metrics.model.registry.PrometheusRegistry
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/** Caching a registry must not change initialization semantics: the `*Initialized` variants have to pre-create the
+  * time series for every combination of label values, so that they are exposed on scrape before the first observation.
+  */
+class CollectorRegistryCachedInitializedSpec extends AnyWordSpec with Matchers {
+
+  import cats.effect.unsafe.implicits.global
+
+  private val labels = LabelsInitialized("baz", Nel.of("v1", "v2"))
+
+  "cached collector registry" should {
+
+    "pre-create label values for gaugeInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.gaugeInitialized("foo", "bar", labels)
+      }
+    }
+
+    "pre-create label values for counterInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.counterInitialized("foo", "bar", labels)
+      }
+    }
+
+    "pre-create label values for summaryInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.summaryInitialized("foo", "bar", Quantiles.Empty, labels)
+      }
+    }
+
+    "pre-create label values for histogramInitialized" in {
+      verifyCachingPreservesInitialization {
+        _.histogramInitialized("foo", "bar", Buckets(Nel.one(42d)), labels)
+      }
+    }
+  }
+
+  private def verifyCachingPreservesInitialization(
+    createMetric: CollectorRegistry[IO] => Resource[IO, Any],
+  ): Assertion = {
+    val expected = scrape(caching = false, createMetric)
+    val actual = scrape(caching = true, createMetric)
+
+    expected should include("""baz="v1"""")
+    actual shouldBe expected
+  }
+
+  private def scrape(
+    caching: Boolean,
+    createMetric: CollectorRegistry[IO] => Resource[IO, Any],
+  ): String = {
+    val prometheus = Prometheus[IO](new PrometheusRegistry())
+    val res = for {
+      prometheus <- if (caching) prometheus.withCaching.toResource else prometheus.pure[IO].toResource
+      _ <- createMetric(prometheus.registry)
+    } yield prometheus
+    res.use(_.write004).unsafeRunSync()
+  }
+}

--- a/smetrics/src/main/scala/com/evolutiongaming/smetrics/CollectorRegistry.scala
+++ b/smetrics/src/main/scala/com/evolutiongaming/smetrics/CollectorRegistry.scala
@@ -424,7 +424,7 @@ object CollectorRegistry {
         name = name,
         names = magnet.names(labels),
         ofType = "gauge",
-        create = registry.gauge(name, help, labels)(magnet),
+        create = registry.gaugeInitialized(name, help, labels)(magnet),
       )
 
     override def counter[A, B[_]](
@@ -452,7 +452,7 @@ object CollectorRegistry {
         name = name,
         names = magnet.names(labels),
         ofType = "counter",
-        create = registry.counter(name, help, labels)(magnet),
+        create = registry.counterInitialized(name, help, labels)(magnet),
       )
 
     override def summary[A, B[_]](
@@ -482,7 +482,7 @@ object CollectorRegistry {
         name = name,
         names = magnet.names(labels),
         ofType = "summary",
-        create = registry.summary(name, help, quantiles, labels)(magnet),
+        create = registry.summaryInitialized(name, help, quantiles, labels)(magnet),
       )
 
     override def histogram[A, B[_]](
@@ -512,7 +512,7 @@ object CollectorRegistry {
         name = name,
         names = magnet.names(labels),
         ofType = "histogram",
-        create = registry.histogram(name, help, buckets, labels)(magnet),
+        create = registry.histogramInitialized(name, help, buckets, labels)(magnet),
       )
 
     override def info[A, B[_]](


### PR DESCRIPTION
All four Initialized methods in CollectorRegistry.Cached delegate to their non-initialized counterparts.
Although it compiles because LabelsMagnetInitialized extends LabelsMagnet, both backends receive initialLabelValues = List.empty. This means that pre-created time series never appear on the first scrape, which defeats the entire purpose of the Initialized variants for anyone using a cached registry. No test covers this combination, which is how it survived.