### PR TITLE
Add threads metrics module

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,36 @@ Right now there are two options available:
 Return type is `Resource[F, _]` rather than `F[_]` because most often underlying metrics implementation upon a call registers your metrics with shared registry.
 Hence `release` hook of `Resource` being used in order to de-register particular metrics from shared registry.
 
+## Thread pool metrics
+
+`smetrics-threads` module gauges the number of live JVM threads per thread pool as `dispatcher_threads{poolName}`.
+
+The JVM does not expose which pool a thread belongs to, so threads are attributed to pools by their name. Naming
+schemes are application specific, hence the matcher is yours to provide. Threads the matcher does not recognise are
+not reported:
+
+```scala
+  import com.evolutiongaming.smetrics.{CollectorRegistry, MeterThreads}
+
+  val poolNameOf: MeterThreads.PoolNameOf = { threadName =>
+    if (threadName.startsWith("io-compute")) Some("cats-effect") else None
+  }
+
+  def meterThreads[F[_]: Async](collectorRegistry: CollectorRegistry[F]): Resource[F, Unit] = {
+    MeterThreads.make[F](collectorRegistry, poolNameOf)
+  }
+```
+
+Threads are re-sampled every `MeterThreads.DefaultInterval`. To change the prefix, the interval, or the set of
+sampled threads, pass your own `Metrics` and thread source instead. `threads` is an effect, re-run on every sample:
+
+```scala
+  for {
+    metrics <- MeterThreads.Metrics.make[F](collectorRegistry, prefix = "custom")
+    result  <- MeterThreads.make[F](metrics, poolNameOf, threads = MeterThreads.threads[F], interval = 5.minutes)
+  } yield result
+```
+
 ## Setup
 
 ```scala
@@ -115,4 +145,10 @@ For sttp3 use `smetrics-sttp3` module:
 
 ```scala
 libraryDependencies += "com.evolutiongaming" %% "smetrics-sttp3" % "x.y.z"
+```
+
+For thread pool metrics use `smetrics-threads` module:
+
+```scala
+libraryDependencies += "com.evolutiongaming" %% "smetrics-threads" % "x.y.z"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val root = project
     publish / skip := true,
     name := "smetrics-parent",
   )
-  .aggregate(smetrics, prometheus, http4s, doobie, prometheus_v1, logback, sttp3, sttp4)
+  .aggregate(smetrics, prometheus, http4s, doobie, prometheus_v1, logback, sttp3, sttp4, threads)
 
 lazy val smetrics = project
   .in(file("smetrics"))
@@ -163,7 +163,21 @@ lazy val sttp4 = project
     libraryDependencies ++= Seq(
       Dependencies.Sttp4.core,
       Dependencies.Sttp4.catsBackend % Test,
-    )
+    ),
+  )
+
+lazy val threads = project
+  .in(file("modules/threads"))
+  .settings(commonSettings)
+  .dependsOn(smetrics % "compile->compile;test->test", prometheus % "test->compile")
+  .settings(
+    name := "smetrics-threads",
+    // Remove this line right after the first release, so the module gets checked like every other one.
+    mimaPreviousArtifacts := Set.empty,
+    libraryDependencies ++= Seq(
+      Cats.effectTestkit % Test,
+      scalatest % Test,
+    ),
   )
 
 def crossSettings[T](scalaVersion: String, if3: Seq[T], if2: Seq[T]): Seq[T] = {

--- a/modules/threads/src/main/scala/com/evolutiongaming/smetrics/MeterThreads.scala
+++ b/modules/threads/src/main/scala/com/evolutiongaming/smetrics/MeterThreads.scala
@@ -1,0 +1,148 @@
+package com.evolutiongaming.smetrics
+
+import cats.effect.{Async, Resource, Sync, Temporal}
+import cats.syntax.all.*
+
+import java.lang.management.ManagementFactory
+import scala.concurrent.duration.*
+
+/**
+ * Periodically gauges the number of live threads of every thread pool.
+ *
+ * The JVM exposes no pool membership for a thread, so threads are attributed to pools by their
+ * name, using a caller-supplied [[MeterThreads.PoolNameOf]]. Threads it does not recognise are not
+ * reported at all.
+ */
+object MeterThreads {
+
+  type ThreadName = String
+
+  /**
+   * Name of the pool a thread belongs to, or `None` for a thread which should not be reported.
+   *
+   * Return a bounded set of names. Every name returned once is gauged on every sample from then on,
+   * as a label value of its own, so names derived from per-connection or per-tenant thread names
+   * grow the metric without bound.
+   */
+  type PoolNameOf = ThreadName => Option[String]
+
+  val DefaultInterval: FiniteDuration = 1.minute
+
+  /**
+   * Gauges the threads of the running JVM, see [[threads]], every [[DefaultInterval]].
+   *
+   * Compose [[Metrics.make]] with the overload below to gauge under a different prefix, at a
+   * different interval, or a set of threads other than the ones of the running JVM.
+   */
+  def make[F[_]: Async](
+    collectorRegistry: CollectorRegistry[F],
+    poolNameOf: PoolNameOf,
+  ): Resource[F, Unit] = {
+    for {
+      metrics <- Metrics.make[F](collectorRegistry)
+      result <- make(metrics, poolNameOf, threads[F])
+    } yield result
+  }
+
+  /**
+   * Gauges the threads reported by `threads`, re-sampling them every `interval`.
+   *
+   * The first sample is taken after `interval` has elapsed, so that pools created while the
+   * application is still starting up are not gauged as empty.
+   *
+   * Sampling runs in a background fiber, cancelled on release. A sample which fails, say because
+   * `poolNameOf` threw on a thread name it could not parse, is skipped silently and sampling
+   * carries on at the next interval, rather than leaving the gauges frozen for good.
+   */
+  def make[F[_]: Temporal](
+    metrics: Metrics[F],
+    poolNameOf: PoolNameOf,
+    threads: F[List[ThreadName]],
+    interval: FiniteDuration = DefaultInterval,
+  ): Resource[F, Unit] = {
+
+    def threadCountByPool = {
+      for {
+        threadNames <- threads
+      } yield {
+        threadNames
+          .flatMap { threadName => poolNameOf(threadName) }
+          .groupMapReduce(identity)(_ => 1)(_ + _)
+      }
+    }
+
+    def observe(poolNames: Set[String], threadCounts: Map[String, Int]) = {
+      poolNames.toList.traverse_ { poolName =>
+        metrics.threads(poolName, threadCounts.getOrElse(poolName, 0))
+      }
+    }
+
+    // pool names seen so far are carried over, so that a pool which lost all of its threads is gauged as zero
+    // instead of being left at the value it was last seen with
+    def sample(poolNames: Set[String]) = {
+      for {
+        threadCounts <- threadCountByPool
+        poolNamesSeen = poolNames ++ threadCounts.keySet
+        _ <- observe(poolNamesSeen, threadCounts)
+      } yield poolNamesSeen
+    }
+
+    val process = Set.empty[String].tailRecM { poolNames =>
+      for {
+        _ <- Temporal[F].sleep(interval)
+        sampled <- sample(poolNames).attempt
+      } yield {
+        sampled.getOrElse(poolNames).asLeft[Unit]
+      }
+    }
+
+    Temporal[F].background(process).void
+  }
+
+  /**
+   * Names of all live threads of the running JVM.
+   */
+  def threads[F[_]: Sync]: F[List[ThreadName]] = {
+    Sync[F].blocking {
+      val threadBean = ManagementFactory.getThreadMXBean
+      for {
+        threadInfo <- threadBean.getThreadInfo(threadBean.getAllThreadIds).toList
+        threadName <- Option(threadInfo).flatMap { thread => Option(thread.getThreadName) }.toList
+      } yield threadName
+    }
+  }
+
+  trait Metrics[F[_]] {
+
+    def threads(poolName: String, threads: Int): F[Unit]
+  }
+
+  object Metrics {
+
+    type Prefix = String
+
+    object Prefix {
+
+      /**
+       * Kept as `dispatcher` for backwards compatibility: the resulting `dispatcher_threads` gauge
+       * is the one existing dashboards and alerts are built on.
+       */
+      val Default: Prefix = "dispatcher"
+    }
+
+    def make[F[_]](
+      registry: CollectorRegistry[F],
+      prefix: Prefix = Prefix.Default,
+    ): Resource[F, Metrics[F]] = {
+      for {
+        threadsGauge <- registry.gauge(s"${ prefix }_threads", "Number of threads in pool", LabelNames("poolName"))
+      } yield {
+        new Metrics[F] {
+          def threads(poolName: String, threads: Int): F[Unit] = {
+            threadsGauge.labels(poolName).set(threads.toDouble)
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/threads/src/test/scala/com/evolutiongaming/smetrics/MeterThreadsSpec.scala
+++ b/modules/threads/src/test/scala/com/evolutiongaming/smetrics/MeterThreadsSpec.scala
@@ -1,0 +1,190 @@
+package com.evolutiongaming.smetrics
+
+import cats.effect.testkit.TestControl
+import cats.effect.{IO, Ref, Resource}
+import cats.syntax.all.*
+import com.evolutiongaming.smetrics.IOSuite.*
+import io.prometheus.client as P
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.CountDownLatch
+import scala.concurrent.duration.*
+
+class MeterThreadsSpec extends AsyncFunSuite with Matchers {
+
+  import MeterThreadsSpec.*
+
+  private val poolNameOf: MeterThreads.PoolNameOf = { threadName =>
+    List("worker", "other").find { poolName => threadName.startsWith(s"$poolName-") }
+  }
+
+  test("gauges the thread count of every recognised pool") {
+    val threadNames = List("worker-1", "worker-2", "other-1", "unrecognised-1")
+    val program = for {
+      metrics <- RecordingMetrics.of
+      _ <- MeterThreads
+        .make[IO](metrics, poolNameOf, IO.pure(threadNames))
+        .use { _ => IO.sleep(MeterThreads.DefaultInterval + 30.seconds) }
+      observations <- metrics.observations
+    } yield observations
+
+    TestControl
+      .executeEmbed(program)
+      .map { observations => observations.sorted shouldEqual List("other" -> 1, "worker" -> 2) }
+      .run()
+  }
+
+  test("gauges zero for a pool which no longer has threads") {
+    val program = for {
+      metrics <- RecordingMetrics.of
+      threadNames <- scriptedThreadNames(IO.pure(List("worker-1")), IO.pure(List.empty))
+      _ <- MeterThreads
+        .make[IO](metrics, poolNameOf, threadNames, 1.minute)
+        .use { _ => IO.sleep(150.seconds) }
+      observations <- metrics.observations
+    } yield observations
+
+    TestControl
+      .executeEmbed(program)
+      .map { observations => observations shouldEqual List("worker" -> 1, "worker" -> 0) }
+      .run()
+  }
+
+  test("stops gauging once released") {
+    val program = for {
+      metrics <- RecordingMetrics.of
+      _ <- MeterThreads
+        .make[IO](metrics, poolNameOf, IO.pure(List("worker-1")), 1.minute)
+        .use { _ => IO.sleep(90.seconds) }
+      _ <- IO.sleep(5.minutes)
+      observations <- metrics.observations
+    } yield observations
+
+    TestControl
+      .executeEmbed(program)
+      .map { observations => observations shouldEqual List("worker" -> 1) }
+      .run()
+  }
+
+  test("carries on gauging after poolNameOf throws") {
+    val throwsOnUnparseable: MeterThreads.PoolNameOf = { threadName =>
+      if (threadName == "unparseable") throw new RuntimeException("cannot parse")
+      else poolNameOf(threadName)
+    }
+    val program = for {
+      metrics <- RecordingMetrics.of
+      threadNames <- scriptedThreadNames(IO.pure(List("unparseable")), IO.pure(List("worker-1")))
+      _ <- MeterThreads
+        .make[IO](metrics, throwsOnUnparseable, threadNames, 1.minute)
+        .use { _ => IO.sleep(150.seconds) }
+      observations <- metrics.observations
+    } yield observations
+
+    TestControl
+      .executeEmbed(program)
+      .map { observations => observations shouldEqual List("worker" -> 1) }
+      .run()
+  }
+
+  test("gauges into dispatcher_threads labelled by poolName") {
+    val prometheus = Prometheus[IO](new P.CollectorRegistry())
+    MeterThreads
+      .Metrics
+      .make[IO](prometheus.registry)
+      .use { metrics =>
+        for {
+          _ <- metrics.threads("worker", 3)
+          exported <- prometheus.write004
+        } yield exported should include("""dispatcher_threads{poolName="worker",} 3.0""")
+      }
+      .run()
+  }
+
+  test("threads lists the live threads of the running JVM") {
+    probeThread(ProbeThreadName)
+      .use { _ => MeterThreads.threads[IO] }
+      .map { threadNames => threadNames should contain(ProbeThreadName) }
+      .run()
+  }
+
+  test("gauges the threads of the running JVM under a custom prefix") {
+    val prometheus = Prometheus[IO](new P.CollectorRegistry())
+    val singlePool: MeterThreads.PoolNameOf = { _ => Some("all") }
+    val meterThreads = for {
+      metrics <- MeterThreads.Metrics.make[IO](prometheus.registry, prefix = "custom")
+      result <- MeterThreads.make[IO](metrics, singlePool, MeterThreads.threads[IO], 10.millis)
+    } yield result
+
+    meterThreads
+      .use { _ => gaugedThreadCount(prometheus) }
+      .map { threadCount => threadCount should be > 0.0 }
+      .run()
+  }
+}
+
+object MeterThreadsSpec {
+
+  private val ProbeThreadName = "meter-threads-spec-probe"
+
+  private val CustomThreadCount = """custom_threads\{poolName="all",\} (\d+\.\d+)""".r
+
+  /**
+   * A thread source returning each of `samples` in turn, then an empty list of threads.
+   */
+  private def scriptedThreadNames(
+    samples: IO[List[MeterThreads.ThreadName]]*,
+  ): IO[IO[List[MeterThreads.ThreadName]]] = {
+    Ref.of[IO, List[IO[List[MeterThreads.ThreadName]]]](samples.toList).map { scriptRef =>
+      scriptRef
+        .modify {
+          case next :: rest => (rest, next)
+          case Nil => (List.empty, IO.pure(List.empty))
+        }
+        .flatten
+    }
+  }
+
+  /**
+   * Waits for a sample to be gauged, bounded by the suite timeout.
+   */
+  private def gaugedThreadCount(prometheus: Prometheus[IO]): IO[Double] = {
+    val sampled = prometheus.write004.map { exported =>
+      CustomThreadCount.findFirstMatchIn(exported).map { matched => matched.group(1).toDouble }
+    }
+    (IO.sleep(10.millis) *> sampled).untilDefinedM
+  }
+
+  private def probeThread(name: String): Resource[IO, Unit] = {
+    val start = IO.blocking {
+      val started = new CountDownLatch(1)
+      val stopped = new CountDownLatch(1)
+      val runnable: Runnable = { () =>
+        started.countDown()
+        stopped.await()
+      }
+      val thread = new Thread(runnable, name)
+      thread.setDaemon(true)
+      thread.start()
+      started.await()
+      stopped
+    }
+    Resource.make(start) { stopped => IO.blocking { stopped.countDown() } }.void
+  }
+
+  private class RecordingMetrics(observationsRef: Ref[IO, List[(String, Int)]]) extends MeterThreads.Metrics[IO] {
+
+    def threads(poolName: String, threads: Int): IO[Unit] = {
+      observationsRef.update { observations => observations :+ (poolName -> threads) }
+    }
+
+    def observations: IO[List[(String, Int)]] = observationsRef.get
+  }
+
+  private object RecordingMetrics {
+
+    def of: IO[RecordingMetrics] = {
+      Ref.of[IO, List[(String, Int)]](List.empty).map { observationsRef => new RecordingMetrics(observationsRef) }
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,10 @@ object Dependencies {
   val doobie = "org.tpolecat" %% "doobie-core" % "1.0.0-RC11"
 
   object Cats {
+    private val effectVersion = "3.7.0"
     val core = "org.typelevel" %% "cats-core" % "2.13.0"
-    val effect = "org.typelevel" %% "cats-effect" % "3.7.0"
+    val effect = "org.typelevel" %% "cats-effect" % effectVersion
+    val effectTestkit = "org.typelevel" %% "cats-effect-testkit" % effectVersion
   }
 
   object PrometheusV1 {


### PR DESCRIPTION
`smetrics-threads` module gauges the number of live JVM threads per thread pool as `dispatcher_threads{poolName}`