### PR TITLE
sttp3 and sttp4 modules improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,12 @@ lazy val commonSettings = Seq(
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
   // add mima check exceptions here, like:
 //  ProblemFilters.exclude[ReversedMissingMethodProblem]("com.evolutiongaming.smetrics.CollectorRegistry.info"),
+
+  // private[this] internals of the sttp backends, not reachable through any public API signature
+  ProblemFilters.exclude[Problem]("sttp.client3.smetrics.SmetricsBackend#State*"),
+  ProblemFilters.exclude[Problem]("sttp.client3.smetrics.SmetricsBackend#PrometheusListener*"),
+  ProblemFilters.exclude[Problem]("sttp.client4.smetrics.SmetricsBackend#State*"),
+  ProblemFilters.exclude[Problem]("sttp.client4.smetrics.SmetricsBackend#SmetricsListener*"),
 )
 
 ThisBuild / libraryDependencySchemes ++= Seq(

--- a/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
+++ b/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
@@ -35,7 +35,7 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  * val backend: SttpBackend[IO, Any] = ???
  * val registry: CollectorRegistry[IO] = ???
  *
- * SmetricsBackend.default(backend, registry).use { backend => ??? }
+ * SmetricsBackend.default1(backend, registry).use { backend => ??? }
  * }}}
  *
  * ==Custom Metric Prefixes==
@@ -210,7 +210,7 @@ object SmetricsBackend {
    * @return
    *   A new backend that records metrics according to the provided mappers
    */
-  def apply[F[_]: Clock: Monad, P](
+  def apply[F[_]: Clock: MonadThrow, P](
     delegate: SttpBackend[F, P],
     latencyMapper: (Request[?, ?], Either[Throwable, Response[?]]) => Option[Histogram[F]],
     inProgressMapper: Request[?, ?] => Option[Gauge[F]],
@@ -232,6 +232,7 @@ object SmetricsBackend {
           failureMapper = failureMapper,
           requestSizeMapper = requestSizeMapper,
           responseSizeMapper = responseSizeMapper,
+          discardFailure = discardMetricFailure,
         ),
       ),
     )
@@ -239,7 +240,9 @@ object SmetricsBackend {
 
   /**
    * Binary-compatible predecessor of the outcome-aware overload, kept for released API
-   * compatibility.
+   * compatibility. Unlike that overload, it cannot isolate failures of individual metric effects
+   * (that requires `MonadThrow`, which this method cannot demand without breaking binary
+   * compatibility).
    */
   @deprecated("Use the overload with an outcome-aware latencyMapper", "2.4.6")
   def apply[F[_]: Clock: Monad, P](
@@ -251,17 +254,24 @@ object SmetricsBackend {
     failureMapper: (Request[?, ?], Throwable) => Option[Counter[F]],
     requestSizeMapper: Request[?, ?] => Option[Summary[F]],
     responseSizeMapper: (Request[?, ?], Response[?]) => Option[Summary[F]],
-  ): SttpBackend[F, P] =
-    apply(
-      delegate = delegate,
-      latencyMapper = { (request: Request[?, ?], _: Either[Throwable, Response[?]]) => latencyMapper(request) },
-      inProgressMapper = inProgressMapper,
-      successMapper = successMapper,
-      errorMapper = errorMapper,
-      failureMapper = failureMapper,
-      requestSizeMapper = requestSizeMapper,
-      responseSizeMapper = responseSizeMapper,
+  ): SttpBackend[F, P] = {
+    // redirects should be handled before prometheus
+    new FollowRedirectsBackend[F, P](
+      new ListenerBackend[F, P, State[F]](
+        delegate,
+        new PrometheusListener[F](
+          latencyMapper = { (request: Request[?, ?], _: Either[Throwable, Response[?]]) => latencyMapper(request) },
+          inProgressMapper = inProgressMapper,
+          successMapper = successMapper,
+          errorMapper = errorMapper,
+          failureMapper = failureMapper,
+          requestSizeMapper = requestSizeMapper,
+          responseSizeMapper = responseSizeMapper,
+          discardFailure = identity,
+        ),
+      ),
     )
+  }
 
   /**
    * Creates an STTP backend with automatic metric collection using a CollectorRegistry.
@@ -292,7 +302,7 @@ object SmetricsBackend {
    * val backend: SttpBackend[IO, Any] = ???
    * val registry: CollectorRegistry[IO] = ???
    *
-   * SmetricsBackend.default(backend, registry, prefix = "myapp_").use { metricsBackend =>
+   * SmetricsBackend.default1(backend, registry, prefix = Some("myapp_")).use { metricsBackend =>
    *   basicRequest
    *     .get(uri"https://api.example.com/users")
    *     .send(metricsBackend)
@@ -304,7 +314,7 @@ object SmetricsBackend {
    * @param collectorRegistry
    *   The smetrics collector registry to register metrics with
    * @param prefix
-   *   The metric name prefix (default: "sttp_")
+   *   The metric name prefix (default: None)
    * @tparam F
    *   The effect type (e.g., IO, Task)
    * @tparam P
@@ -312,18 +322,41 @@ object SmetricsBackend {
    * @return
    *   A Resource that manages the metrics-enabled backend lifecycle
    */
+  def default1[F[_]: Clock: MonadThrow, P](
+    delegate: SttpBackend[F, P],
+    collectorRegistry: CollectorRegistry[F],
+    prefix: Option[String] = None,
+  ): Resource[F, SttpBackend[F, P]] = {
+    val registry = prefix.fold(collectorRegistry)(collectorRegistry.prefixed(_))
+    makeDefault(delegate, registry, discardMetricFailure)
+  }
+
+  /**
+   * Binary-compatible predecessor of [[default1]], kept for released API compatibility. Unlike
+   * [[default1]], it cannot isolate failures of individual metric effects: that requires
+   * `MonadThrow`, which this method cannot demand without breaking binary compatibility, and a
+   * `MonadThrow` overload under the same name would make every existing call site ambiguous
+   * (overloads differing only in implicit parameters cannot be resolved).
+   */
+  @deprecated("Use default1, which also isolates metric recording failures", "2.4.6")
   def default[F[_]: Clock: Monad, P](
     delegate: SttpBackend[F, P],
     collectorRegistry: CollectorRegistry[F],
     prefix: Option[String] = None,
   ): Resource[F, SttpBackend[F, P]] = {
     val registry = prefix.fold(collectorRegistry)(collectorRegistry.prefixed(_))
-    makeDefault(delegate, registry)
+    makeDefault(delegate, registry, identity[F[Unit]])
   }
+
+  // metric recording must never fail the request, hence individual metric failures are
+  // discarded and the remaining metrics are still recorded
+  private def discardMetricFailure[F[_]: MonadThrow]: F[Unit] => F[Unit] =
+    _.handleError(_ => ())
 
   private def makeDefault[F[_]: Clock: Monad, P](
     delegate: SttpBackend[F, P],
     collectorRegistry: CollectorRegistry[F],
+    discardFailure: F[Unit] => F[Unit],
   ): Resource[F, SttpBackend[F, P]] =
     for {
       latency <- collectorRegistry.histogram(
@@ -377,6 +410,7 @@ object SmetricsBackend {
             failureMapper = { (req, _) => failure.labels(methodLabel(req)).some },
             requestSizeMapper = { req => requestSize.labels(methodLabel(req)).some },
             responseSizeMapper = { (req, rsp) => responseSize.labels(methodLabel(req), statusLabel(rsp)).some },
+            discardFailure = discardFailure,
           ),
         ),
       )
@@ -408,6 +442,10 @@ object SmetricsBackend {
     failureMapper: (Request[?, ?], Throwable) => Option[Counter[F]],
     requestSizeMapper: Request[?, ?] => Option[Summary[F]],
     responseSizeMapper: (Request[?, ?], Response[?]) => Option[Summary[F]],
+    // how to handle a failing metric effect: [[discardMetricFailure]] for the MonadThrow-based
+    // entry points, identity (failures propagate, pre-2.4.6 behavior) for the released
+    // Monad-based ones which cannot demand MonadThrow without breaking binary compatibility
+    discardFailure: F[Unit] => F[Unit],
   ) extends RequestListener[F, State[F]] {
 
     private val unit = Applicative[F].unit
@@ -437,16 +475,6 @@ object SmetricsBackend {
     ): F[Unit] =
       latencyMapper(request, outcome).fold(unit) { histogram =>
         elapsed.flatMap { elapsed => histogram.observe(elapsed.toUnit(SECONDS)) }
-      }
-
-    // metric recording must never fail the request: when the effect type can handle errors
-    // (which holds for every practical F, e.g. IO), individual metric failures are discarded
-    // and the remaining metrics are still recorded; a MonadThrow constraint would express this
-    // in the signature, but adding it would break binary compatibility of the released API
-    private val discardFailure: F[Unit] => F[Unit] =
-      Monad[F] match {
-        case monadError: MonadError[F, Any] @unchecked => effect => monadError.handleError(effect)(_ => ())
-        case _ => identity
       }
 
     private def recordAll(effects: F[Unit]*): F[Unit] =

--- a/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
+++ b/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
@@ -9,6 +9,8 @@ import com.evolutiongaming.smetrics.*
 import sttp.client3.*
 import sttp.client3.listener.*
 
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
+
 /**
  * Factory for creating STTP backends that record metrics using smetrics.
  *
@@ -60,7 +62,7 @@ import sttp.client3.listener.*
  *
  * val backend = SmetricsBackend(
  *   delegate = underlyingBackend,
- *   latencyMapper = { req => ??? },
+ *   latencyMapper = { (req, outcome) => ??? },
  *   inProgressMapper = ???,
  *   successMapper = ???,
  *   errorMapper = ???,
@@ -186,7 +188,9 @@ object SmetricsBackend {
    * @param delegate
    *   The underlying STTP backend to wrap
    * @param latencyMapper
-   *   Function to map a request to a histogram for recording latency
+   *   Function to map a request and its outcome (the failure, or the response) to a histogram for
+   *   recording latency. It is resolved when the outcome is known, so label values may depend on
+   *   the response status.
    * @param inProgressMapper
    *   Function to map a request to a gauge for tracking in-progress requests
    * @param successMapper
@@ -208,7 +212,7 @@ object SmetricsBackend {
    */
   def apply[F[_]: Clock: Monad, P](
     delegate: SttpBackend[F, P],
-    latencyMapper: Request[?, ?] => Option[Histogram[F]],
+    latencyMapper: (Request[?, ?], Either[Throwable, Response[?]]) => Option[Histogram[F]],
     inProgressMapper: Request[?, ?] => Option[Gauge[F]],
     successMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
     errorMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
@@ -221,17 +225,43 @@ object SmetricsBackend {
       new ListenerBackend[F, P, State[F]](
         delegate,
         new PrometheusListener[F](
-          latencyMapper: Request[?, ?] => Option[Histogram[F]],
-          inProgressMapper: Request[?, ?] => Option[Gauge[F]],
-          successMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
-          errorMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
-          failureMapper: (Request[?, ?], Throwable) => Option[Counter[F]],
-          requestSizeMapper: Request[?, ?] => Option[Summary[F]],
-          responseSizeMapper: (Request[?, ?], Response[?]) => Option[Summary[F]],
+          latencyMapper = latencyMapper,
+          inProgressMapper = inProgressMapper,
+          successMapper = successMapper,
+          errorMapper = errorMapper,
+          failureMapper = failureMapper,
+          requestSizeMapper = requestSizeMapper,
+          responseSizeMapper = responseSizeMapper,
         ),
       ),
     )
   }
+
+  /**
+   * Binary-compatible predecessor of the outcome-aware overload, kept for released API
+   * compatibility.
+   */
+  @deprecated("Use the overload with an outcome-aware latencyMapper", "2.4.6")
+  def apply[F[_]: Clock: Monad, P](
+    delegate: SttpBackend[F, P],
+    latencyMapper: Request[?, ?] => Option[Histogram[F]],
+    inProgressMapper: Request[?, ?] => Option[Gauge[F]],
+    successMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
+    errorMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
+    failureMapper: (Request[?, ?], Throwable) => Option[Counter[F]],
+    requestSizeMapper: Request[?, ?] => Option[Summary[F]],
+    responseSizeMapper: (Request[?, ?], Response[?]) => Option[Summary[F]],
+  ): SttpBackend[F, P] =
+    apply(
+      delegate = delegate,
+      latencyMapper = { (request: Request[?, ?], _: Either[Throwable, Response[?]]) => latencyMapper(request) },
+      inProgressMapper = inProgressMapper,
+      successMapper = successMapper,
+      errorMapper = errorMapper,
+      failureMapper = failureMapper,
+      requestSizeMapper = requestSizeMapper,
+      responseSizeMapper = responseSizeMapper,
+    )
 
   /**
    * Creates an STTP backend with automatic metric collection using a CollectorRegistry.
@@ -340,7 +370,7 @@ object SmetricsBackend {
         new ListenerBackend[F, P, State[F]](
           delegate,
           new PrometheusListener[F](
-            latencyMapper = { req => latency.labels(methodLabel(req)).some },
+            latencyMapper = { (req, _) => latency.labels(methodLabel(req)).some },
             inProgressMapper = { req => inProgress.labels(methodLabel(req)).some },
             successMapper = { (req, rsp) => success.labels(methodLabel(req), statusLabel(rsp)).some },
             errorMapper = { (req, rsp) => error.labels(methodLabel(req), statusLabel(rsp)).some },
@@ -356,41 +386,22 @@ object SmetricsBackend {
    * Internal state passed between request lifecycle hooks.
    *
    * @param recordLatency
-   *   Effect to record the request latency measurement
+   *   Effect to record the request latency for a given request outcome
    * @param decInProgress
    *   Effect to decrement the in-progress requests gauge
    * @tparam F
    *   The effect type
    */
-  private[this] final case class State[F[_]](recordLatency: F[Unit], decInProgress: F[Unit])
+  private[this] final case class State[F[_]](
+    recordLatency: Either[Throwable, Response[?]] => F[Unit],
+    decInProgress: F[Unit],
+  )
 
   /**
    * Internal RequestListener implementation that records metrics for HTTP requests.
-   *
-   * This listener hooks into the STTP request lifecycle to:
-   *   - Start latency measurement and increment in-progress gauge before the request
-   *   - Record latency, decrement in-progress gauge, and update counters after the request
-   *   - Handle both successful responses and exceptions
-   *
-   * @param latencyMapper
-   *   Function to map a request to a histogram for recording latency
-   * @param inProgressMapper
-   *   Function to map a request to a gauge for tracking in-progress requests
-   * @param successMapper
-   *   Function to map a request and response to a counter for successful requests
-   * @param errorMapper
-   *   Function to map a request and response to a counter for errored requests
-   * @param failureMapper
-   *   Function to map a request and exception to a counter for failed requests
-   * @param requestSizeMapper
-   *   Function to map a request to a summary for request sizes
-   * @param responseSizeMapper
-   *   Function to map a request and response to a summary for response sizes
-   * @tparam F
-   *   The effect type
    */
   private[this] class PrometheusListener[F[_]: Clock: Monad](
-    latencyMapper: Request[?, ?] => Option[Histogram[F]],
+    latencyMapper: (Request[?, ?], Either[Throwable, Response[?]]) => Option[Histogram[F]],
     inProgressMapper: Request[?, ?] => Option[Gauge[F]],
     successMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
     errorMapper: (Request[?, ?], Response[?]) => Option[Counter[F]],
@@ -399,67 +410,48 @@ object SmetricsBackend {
     responseSizeMapper: (Request[?, ?], Response[?]) => Option[Summary[F]],
   ) extends RequestListener[F, State[F]] {
 
-    /**
-     * Called before a request is sent.
-     *
-     * This method:
-     *   - Starts latency measurement if a latency histogram is configured
-     *   - Increments the in-progress gauge if configured
-     *   - Records request size if a summary is configured
-     *
-     * Returns State containing effects to record latency and decrement in-progress gauge.
-     *
-     * @param request
-     *   The HTTP request about to be sent
-     * @return
-     *   State containing cleanup effects to run after the request completes
-     */
+    private val unit = Applicative[F].unit
+
     override def beforeRequest(request: Request[?, ?]): F[State[F]] = {
-      val latency = for {
-        latency <- latencyMapper(request)
-      } yield
-        for {
-          duration <- MeasureDuration[F].start
-        } yield duration.flatMap { duration => latency.observe(duration.toUnit(scala.concurrent.duration.SECONDS)) }
-
-      val inProgress = inProgressMapper(request)
-
       val requestSize = for {
         requestSize <- requestSizeMapper(request)
         size <- request.contentLength.map(_.toDouble)
       } yield requestSize.observe(size)
 
-      val unit = Applicative[F].unit
+      val inProgress = inProgressMapper(request)
 
       for {
-        recordLatency <- latency.getOrElse(unit.pure[F])
+        elapsed <- MeasureDuration[F].start
         _ <- requestSize.getOrElse(unit)
         _ <- inProgress.map(_.inc()).getOrElse(unit)
       } yield State(
-        recordLatency = recordLatency,
+        recordLatency = recordLatency(request, _, elapsed),
         decInProgress = inProgress.map(_.dec()).getOrElse(unit),
       )
     }
 
-    /**
-     * Called when a request throws an exception.
-     *
-     * This method:
-     *   - Handles HttpError exceptions by treating them as successful responses with error status
-     *     codes
-     *   - Records latency measurement
-     *   - Decrements in-progress gauge
-     *   - Increments failure counter for non-HTTP exceptions
-     *
-     * @param request
-     *   The HTTP request that failed
-     * @param state
-     *   State containing cleanup effects from beforeRequest
-     * @param e
-     *   The exception that was thrown
-     * @return
-     *   Effect completing the metric recording
-     */
+    private def recordLatency(
+      request: Request[?, ?],
+      outcome: Either[Throwable, Response[?]],
+      elapsed: F[FiniteDuration],
+    ): F[Unit] =
+      latencyMapper(request, outcome).fold(unit) { histogram =>
+        elapsed.flatMap { elapsed => histogram.observe(elapsed.toUnit(SECONDS)) }
+      }
+
+    // metric recording must never fail the request: when the effect type can handle errors
+    // (which holds for every practical F, e.g. IO), individual metric failures are discarded
+    // and the remaining metrics are still recorded; a MonadThrow constraint would express this
+    // in the signature, but adding it would break binary compatibility of the released API
+    private val discardFailure: F[Unit] => F[Unit] =
+      Monad[F] match {
+        case monadError: MonadError[F, Any] @unchecked => effect => monadError.handleError(effect)(_ => ())
+        case _ => identity
+      }
+
+    private def recordAll(effects: F[Unit]*): F[Unit] =
+      effects.toList.traverse_(discardFailure)
+
     override def requestException(
       request: Request[?, ?],
       state: State[F],
@@ -469,52 +461,32 @@ object SmetricsBackend {
         case Some(HttpError(body, statusCode)) =>
           requestSuccessful(request, Response(body, statusCode).copy(request = request.onlyMetadata), state)
         case _ =>
-          for {
-            _ <- state.recordLatency
-            _ <- state.decInProgress
-            _ <- failureMapper(request, e).map(_.inc()).sequence
-          } yield ()
+          recordAll(
+            state.recordLatency(e.asLeft),
+            state.decInProgress,
+            failureMapper(request, e).fold(unit)(_.inc()),
+          )
       }
     }
 
-    /**
-     * Called when a request completes successfully.
-     *
-     * This method:
-     *   - Records latency measurement
-     *   - Decrements in-progress gauge
-     *   - Records response size if configured
-     *   - Increments success counter for 2xx responses, error counter otherwise
-     *
-     * @param request
-     *   The HTTP request that was sent
-     * @param response
-     *   The HTTP response that was received
-     * @param state
-     *   State containing cleanup effects from beforeRequest
-     * @return
-     *   Effect completing the metric recording
-     */
     override def requestSuccessful(
       request: Request[?, ?],
       response: Response[?],
       state: State[F],
     ): F[Unit] = {
-      for {
-        _ <- state.recordLatency
-        _ <- state.decInProgress
-        _ <- {
-          for {
-            responseSize <- responseSizeMapper(request, response)
-            size <- response.contentLength.map(_.toDouble)
-          } yield responseSize.observe(size)
-        }.sequence
-        counter = if (response.isSuccess)
-          successMapper
-        else
-          errorMapper
-        _ <- counter(request, response).map(_.inc()).sequence
-      } yield ()
+      val responseSize = for {
+        responseSize <- responseSizeMapper(request, response)
+        size <- response.contentLength.map(_.toDouble)
+      } yield responseSize.observe(size)
+
+      val counterMapper = if (response.isSuccess) successMapper else errorMapper
+
+      recordAll(
+        state.recordLatency(response.asRight),
+        state.decInProgress,
+        responseSize.getOrElse(unit),
+        counterMapper(request, response).fold(unit)(_.inc()),
+      )
     }
 
   }

--- a/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
+++ b/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
@@ -72,6 +72,32 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  * )
  * }}}
  *
+ * ==Custom Recording==
+ *
+ * For example size mappers are typed as [[com.evolutiongaming.smetrics.Summary]], but using an actual
+ * summary collector is not mandatory: `Summary` has a single `observe` method, so any recording
+ * strategy can be plugged in by implementing it. For example, recording sizes as a histogram
+ *
+ * {{{
+ * def sizeAsHistogram(histogram: Histogram[F]): Summary[F] =
+ *   new Summary[F] {
+ *     def observe(value: Double): F[Unit] =
+ *       histogram.observe(value)
+ *   }
+ *
+ * val backend = SmetricsBackend(
+ *   delegate = underlyingBackend,
+ *   requestSizeMapper = { req =>
+ *     sizeAsHistogram(
+ *       requestSizeHistogram.labels(methodLabel(req))
+ *     ).some
+ *   },
+ *   ...
+ * )
+ * }}}
+ *
+ * Returning `None` from a mapper disables that metric entirely.
+ *
  * ==Labels==
  *
  * By default, the following labels are attached to metrics:

--- a/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
+++ b/modules/sttp3/src/main/scala/sttp/client3/smetrics/SmetricsBackend.scala
@@ -43,13 +43,13 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  * You can customize the metric name prefix:
  *
  * {{{
- * SmetricsBackend(backend, registry, prefix = "custom_")
+ * SmetricsBackend.default1(backend, registry, prefix = Some("custom_"))
  * }}}
  *
  * This will generate metrics like:
- *   - `custom_request_latency_seconds`
- *   - `custom_requests_in_progress`
- *   - `custom_requests_success_count`
+ *   - `custom_sttp_request_latency_seconds`
+ *   - `custom_sttp_requests_in_progress`
+ *   - `custom_sttp_requests_success_count`
  *   - etc.
  *
  * ==Custom Metric Mappers==
@@ -74,9 +74,10 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  *
  * ==Custom Recording==
  *
- * For example size mappers are typed as [[com.evolutiongaming.smetrics.Summary]], but using an actual
- * summary collector is not mandatory: `Summary` has a single `observe` method, so any recording
- * strategy can be plugged in by implementing it. For example, recording sizes as a histogram
+ * For example, size mappers are typed as [[com.evolutiongaming.smetrics.Summary]], but using an
+ * actual summary collector is not mandatory: `Summary` has a single `observe` method, so any
+ * recording strategy can be plugged in by implementing it. For example, recording sizes as a
+ * histogram:
  *
  * {{{
  * def sizeAsHistogram(histogram: Histogram[F]): Summary[F] =
@@ -270,7 +271,7 @@ object SmetricsBackend {
    * (that requires `MonadThrow`, which this method cannot demand without breaking binary
    * compatibility).
    */
-  @deprecated("Use the overload with an outcome-aware latencyMapper", "2.4.6")
+  @deprecated("Use the overload with an outcome-aware latencyMapper", "2.5.0")
   def apply[F[_]: Clock: Monad, P](
     delegate: SttpBackend[F, P],
     latencyMapper: Request[?, ?] => Option[Histogram[F]],
@@ -364,7 +365,7 @@ object SmetricsBackend {
    * `MonadThrow` overload under the same name would make every existing call site ambiguous
    * (overloads differing only in implicit parameters cannot be resolved).
    */
-  @deprecated("Use default1, which also isolates metric recording failures", "2.4.6")
+  @deprecated("Use default1, which also isolates metric recording failures", "2.5.0")
   def default[F[_]: Clock: Monad, P](
     delegate: SttpBackend[F, P],
     collectorRegistry: CollectorRegistry[F],
@@ -444,6 +445,10 @@ object SmetricsBackend {
 
   /**
    * Internal state passed between request lifecycle hooks.
+   *
+   * Unlike the sttp4 counterpart, no exactly-once guard is needed here: the sttp3
+   * [[sttp.client3.listener.RequestListener]] contract invokes exactly one completion hook per
+   * request.
    *
    * @param recordLatency
    *   Effect to record the request latency for a given request outcome

--- a/modules/sttp3/src/test/scala/sttp/client3/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp3/src/test/scala/sttp/client3/smetrics/SmetricsBackendSpec.scala
@@ -221,7 +221,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
 
         backend = SmetricsBackend(
           stubBackend,
-          latencyMapper = { req =>
+          latencyMapper = { (req, _) =>
             latency.labels(methodLabel(req), backendLabel(req), resourceLabel(req)).some
           },
           inProgressMapper = { req =>

--- a/modules/sttp3/src/test/scala/sttp/client3/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp3/src/test/scala/sttp/client3/smetrics/SmetricsBackendSpec.scala
@@ -136,6 +136,78 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
     }.run()
   }
 
+  test("latency histogram can be labelled by response status") {
+    runIO {
+      val stubBackend = SttpBackendStub[IO, Any](sttp.monad.MonadError[IO]).whenAnyRequest.thenRespondNotFound()
+
+      val resource = for {
+        registry <- InMemoryCollectorRegistry.make.toResource
+        latency <- registry.histogram(
+          name = MetricNames.latency,
+          help = "Request latency in seconds",
+          buckets = Buckets(NonEmptyList.fromListUnsafe(DefaultBuckets)),
+          labels = LabelNames("method", "status"),
+        )
+        backend = SmetricsBackend(
+          stubBackend,
+          latencyMapper = { (req, outcome) =>
+            latency.labels(methodLabel(req), outcome.fold(_ => "failure", statusLabel)).some
+          },
+          inProgressMapper = { _ => Option.empty[Gauge[IO]] },
+          successMapper = { (_, _) => Option.empty[Counter[IO]] },
+          errorMapper = { (_, _) => Option.empty[Counter[IO]] },
+          failureMapper = { (_, _) => Option.empty[Counter[IO]] },
+          requestSizeMapper = { _ => Option.empty[Summary[IO]] },
+          responseSizeMapper = { (_, _) => Option.empty[Summary[IO]] },
+        )
+        _ <- Resource.eval(basicRequest.get(`/`).send(backend))
+        events <- registry.events.toResource
+      } yield withClue(events) {
+        events.collect {
+          case MetricEvent(MetricNames.latency, "histogram", List("GET", "4xx"), "observe", _) => ()
+        }.size shouldBe 1
+      }
+
+      resource.use(_.pure[IO])
+    }
+  }
+
+  test("gauge decrement is not lost when latency recording fails") {
+    runIO {
+      val stubBackend = SttpBackendStub[IO, Any](sttp.monad.MonadError[IO]).whenAnyRequest.thenRespondOk()
+
+      val failingLatency: Histogram[IO] = new Histogram[IO] {
+        override def observe(value: Double): IO[Unit] =
+          IO.raiseError(new RuntimeException("metrics store unavailable"))
+      }
+
+      val resource = for {
+        registry <- InMemoryCollectorRegistry.make.toResource
+        inProgress <- registry.gauge(
+          name = MetricNames.inProgress,
+          help = "Number of requests in progress",
+          labels = LabelNames("method"),
+        )
+        backend = SmetricsBackend(
+          stubBackend,
+          latencyMapper = { (_, _) => failingLatency.some },
+          inProgressMapper = { req => inProgress.labels(methodLabel(req)).some },
+          successMapper = { (_, _) => Option.empty[Counter[IO]] },
+          errorMapper = { (_, _) => Option.empty[Counter[IO]] },
+          failureMapper = { (_, _) => Option.empty[Counter[IO]] },
+          requestSizeMapper = { _ => Option.empty[Summary[IO]] },
+          responseSizeMapper = { (_, _) => Option.empty[Summary[IO]] },
+        )
+        _ <- Resource.eval(basicRequest.get(`/`).send(backend))
+        events <- registry.events.toResource
+      } yield withClue(events) {
+        events.count(event => event.name == MetricNames.inProgress && event.op == "dec") shouldBe 1
+      }
+
+      resource.use(_.pure[IO])
+    }
+  }
+
   test("configure prefix") {
     runIO {
       val stubBackend = SttpBackendStub[IO, Any](sttp.monad.MonadError[IO]).whenAnyRequest.thenRespondOk()

--- a/modules/sttp3/src/test/scala/sttp/client3/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp3/src/test/scala/sttp/client3/smetrics/SmetricsBackendSpec.scala
@@ -27,7 +27,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
     for {
       registry <- InMemoryCollectorRegistry.make
       backendAllocated <- SmetricsBackend
-        .default(
+        .default1(
           stub(SttpBackendStub[IO, Any](sttp.monad.MonadError[IO])),
           registry,
         )
@@ -143,7 +143,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
       for {
         registry <- InMemoryCollectorRegistry.make
         backendAllocated <- SmetricsBackend
-          .default(
+          .default1(
             stubBackend,
             registry,
             prefix = Some("prefix_"),

--- a/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
+++ b/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
@@ -12,6 +12,9 @@ import sttp.client4.listener.*
 import sttp.client4.wrappers.FollowRedirectsBackend
 import sttp.model.ResponseMetadata
 
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
+
 /**
  * Factory for creating STTP backends that record metrics using smetrics.
  *
@@ -75,7 +78,7 @@ import sttp.model.ResponseMetadata
  *
  * val backend = SmetricsBackend(
  *   delegate = underlyingBackend,
- *   durationMapper = { req => ??? },
+ *   durationMapper = { (req, outcome) => ??? },
  *   activeMapper = ???,
  *   successMapper = ???,
  *   errorMapper = ???,
@@ -97,6 +100,12 @@ import sttp.model.ResponseMetadata
  * {{{
  * .005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10
  * }}}
+ *
+ * ==WebSockets==
+ *
+ * Durations are intentionally not recorded for WebSocket requests, mirroring sttp's own
+ * `PrometheusBackend`: the measured time would cover the whole socket lifetime rather than a
+ * request-response roundtrip. All other metrics are recorded for WebSocket requests as usual.
  *
  * ==Thread Safety==
  *
@@ -208,7 +217,9 @@ object SmetricsBackend {
    * @param delegate
    *   The underlying STTP backend to wrap
    * @param durationMapper
-   *   Function to map a request to a histogram for recording request duration
+   *   Function to map a request and its outcome (the failure, or the response metadata) to a
+   *   histogram for recording request duration. It is resolved when the outcome is known, so label
+   *   values may depend on the response status. Durations are not recorded for WebSocket requests.
    * @param activeMapper
    *   Function to map a request to a gauge for tracking active requests
    * @param successMapper
@@ -228,7 +239,7 @@ object SmetricsBackend {
    */
   def apply[F[_]: Clock: Monad: ToTry](
     delegate: Backend[F],
-    durationMapper: GenericRequest[?, ?] => Option[Histogram[F]],
+    durationMapper: (GenericRequest[?, ?], Either[Throwable, ResponseMetadata]) => Option[Histogram[F]],
     activeMapper: GenericRequest[?, ?] => Option[Gauge[F]],
     successMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
     errorMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
@@ -255,7 +266,7 @@ object SmetricsBackend {
 
   def apply[F[_]: Clock: Monad: ToTry, C](
     delegate: StreamBackend[F, C],
-    durationMapper: GenericRequest[?, ?] => Option[Histogram[F]],
+    durationMapper: (GenericRequest[?, ?], Either[Throwable, ResponseMetadata]) => Option[Histogram[F]],
     activeMapper: GenericRequest[?, ?] => Option[Gauge[F]],
     successMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
     errorMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
@@ -279,6 +290,62 @@ object SmetricsBackend {
       ),
     )
   }
+
+  /**
+   * Binary-compatible predecessor of the outcome-aware overload, kept for released API
+   * compatibility.
+   */
+  @deprecated("Use the overload with an outcome-aware durationMapper", "2.4.6")
+  def apply[F[_]: Clock: Monad: ToTry](
+    delegate: Backend[F],
+    durationMapper: GenericRequest[?, ?] => Option[Histogram[F]],
+    activeMapper: GenericRequest[?, ?] => Option[Gauge[F]],
+    successMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
+    errorMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
+    failureMapper: (GenericRequest[?, ?], Throwable) => Option[Counter[F]],
+    requestSizeMapper: GenericRequest[?, ?] => Option[Summary[F]],
+    responseSizeMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Summary[F]],
+  ): Backend[F] =
+    apply(
+      delegate = delegate,
+      durationMapper = {
+        (request: GenericRequest[?, ?], _: Either[Throwable, ResponseMetadata]) => durationMapper(request)
+      },
+      activeMapper = activeMapper,
+      successMapper = successMapper,
+      errorMapper = errorMapper,
+      failureMapper = failureMapper,
+      requestSizeMapper = requestSizeMapper,
+      responseSizeMapper = responseSizeMapper,
+    )
+
+  /**
+   * Binary-compatible predecessor of the outcome-aware overload, kept for released API
+   * compatibility.
+   */
+  @deprecated("Use the overload with an outcome-aware durationMapper", "2.4.6")
+  def apply[F[_]: Clock: Monad: ToTry, C](
+    delegate: StreamBackend[F, C],
+    durationMapper: GenericRequest[?, ?] => Option[Histogram[F]],
+    activeMapper: GenericRequest[?, ?] => Option[Gauge[F]],
+    successMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
+    errorMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
+    failureMapper: (GenericRequest[?, ?], Throwable) => Option[Counter[F]],
+    requestSizeMapper: GenericRequest[?, ?] => Option[Summary[F]],
+    responseSizeMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Summary[F]],
+  ): StreamBackend[F, C] =
+    apply(
+      delegate = delegate,
+      durationMapper = {
+        (request: GenericRequest[?, ?], _: Either[Throwable, ResponseMetadata]) => durationMapper(request)
+      },
+      activeMapper = activeMapper,
+      successMapper = successMapper,
+      errorMapper = errorMapper,
+      failureMapper = failureMapper,
+      requestSizeMapper = requestSizeMapper,
+      responseSizeMapper = responseSizeMapper,
+    )
 
   /**
    * Creates an STTP backend with automatic metric collection using a CollectorRegistry.
@@ -402,7 +469,7 @@ object SmetricsBackend {
         quantiles = Quantiles.Default,
       )
     } yield new SmetricsListener[F](
-      durationMapper = { req => duration.labels(methodLabel(req)).some },
+      durationMapper = { (req, _) => duration.labels(methodLabel(req)).some },
       activeMapper = { req => active.labels(methodLabel(req)).some },
       successMapper = { (req, rsp) => success.labels(methodLabel(req), statusLabel(rsp)).some },
       errorMapper = { (req, rsp) => error.labels(methodLabel(req), statusLabel(rsp)).some },
@@ -415,41 +482,37 @@ object SmetricsBackend {
    * Internal state passed between request lifecycle hooks.
    *
    * @param recordDuration
-   *   Effect to record the request duration measurement
+   *   Effect to record the request duration for a given request outcome
    * @param decActive
    *   Effect to decrement the active requests gauge
+   * @param recorded
+   *   Guard ensuring metrics are recorded exactly once per request: depending on the response
+   *   handling description, [[sttp.client4.listener.RequestListener]] may invoke several of the
+   *   completion hooks for a single request, or any one of them
    * @tparam F
    *   The effect type
    */
-  private[this] final case class State[F[_]](recordDuration: F[Unit], decActive: F[Unit])
+  private[this] final case class State[F[_]](
+    recordDuration: Either[Throwable, ResponseMetadata] => F[Unit],
+    decActive: F[Unit],
+    // AtomicBoolean instead of Ref[F, Boolean]: creating a Ref requires a Sync/Ref.Make constraint,
+    // which cannot be added without breaking binary compatibility of the released API; if bin-compat
+    // constraints are ever dropped (e.g. in a 3.0), Ref[F, Boolean] + getAndSet would be the
+    // idiomatic replacement
+    recorded: AtomicBoolean,
+  )
 
   /**
    * Internal RequestListener implementation that records metrics for HTTP requests.
    *
-   * This listener hooks into the STTP request lifecycle to:
-   *   - Start duration measurement and increment active gauge before the request
-   *   - Record duration, decrement active gauge, and update counters after the request
-   *   - Handle both successful responses and exceptions
-   *
-   * @param durationMapper
-   *   Function to map a request to a histogram for recording duration
-   * @param activeMapper
-   *   Function to map a request to a gauge for tracking active requests
-   * @param successMapper
-   *   Function to map a request and response to a counter for successful requests
-   * @param errorMapper
-   *   Function to map a request and response to a counter for errored requests
-   * @param failureMapper
-   *   Function to map a request and exception to a counter for failed requests
-   * @param requestSizeMapper
-   *   Function to map a request to a summary for request sizes
-   * @param responseSizeMapper
-   *   Function to map a request and response to a summary for response sizes
-   * @tparam F
-   *   The effect type
+   * Metrics are recorded exactly once per request, by whichever completion hook fires first:
+   *   - `responseBodyReceived` for safe, non-WebSocket requests whose body was fully received
+   *   - `responseHandled` as the fallback for WebSockets, response exceptions raised before the
+   *     body was received, and streaming bodies that are never fully consumed
+   *   - `exception` for requests that failed without response metadata (including cancellation)
    */
   private[this] class SmetricsListener[F[_]: Clock: Monad: ToTry](
-    durationMapper: GenericRequest[?, ?] => Option[Histogram[F]],
+    durationMapper: (GenericRequest[?, ?], Either[Throwable, ResponseMetadata]) => Option[Histogram[F]],
     activeMapper: GenericRequest[?, ?] => Option[Gauge[F]],
     successMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
     errorMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Counter[F]],
@@ -458,155 +521,115 @@ object SmetricsBackend {
     responseSizeMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Summary[F]],
   ) extends RequestListener[F, State[F]] {
 
-    /**
-     * Called before a request is sent.
-     *
-     * This method:
-     *   - Starts duration measurement if a duration histogram is configured
-     *   - Increments the active gauge if configured
-     *   - Records request size if a summary is configured
-     *
-     * Returns State containing effects to record duration and decrement active gauge.
-     *
-     * @param request
-     *   The HTTP request about to be sent
-     * @return
-     *   State containing cleanup effects to run after the request completes
-     */
+    private val unit = Applicative[F].unit
+
     override def before(request: GenericRequest[?, ?]): F[State[F]] = {
-      val duration = for {
-        duration <- durationMapper(request)
-      } yield
-        for {
-          recordDuration <- MeasureDuration[F].start
-        } yield recordDuration.flatMap { recordDuration =>
-          duration.observe(recordDuration.toUnit(scala.concurrent.duration.SECONDS).toDouble)
-        }
-
-      val active = activeMapper(request)
-
-      val requestSizeEffect = for {
+      val requestSize = for {
         size <- request.contentLength.map(_.toDouble)
         summary <- requestSizeMapper(request)
       } yield summary.observe(size)
 
+      val active = activeMapper(request)
+
       for {
-        recordDuration <- duration match {
-          case Some(recordDuration) if !request.isWebSocket => recordDuration
-          case _ => Applicative[F].unit.pure[F]
-        }
-        _ <- requestSizeEffect.getOrElse(Applicative[F].unit)
-        _ <- active.map(_.inc()).getOrElse(Applicative[F].unit)
-        decActive = active.map(_.dec()).getOrElse(Applicative[F].unit)
-      } yield State(recordDuration = recordDuration, decActive = decActive)
+        elapsed <- MeasureDuration[F].start
+        _ <- requestSize.getOrElse(unit)
+        _ <- active.map(_.inc()).getOrElse(unit)
+      } yield State(
+        recordDuration = recordDuration(request, _, elapsed),
+        decActive = active.map(_.dec()).getOrElse(unit),
+        recorded = new AtomicBoolean(false),
+      )
     }
 
-    /**
-     * Helper method to capture response metrics.
-     *
-     * @param request
-     *   The HTTP request that was sent
-     * @param response
-     *   The HTTP response metadata
-     * @param state
-     *   State containing cleanup effects from before
-     * @return
-     *   Effect completing the metric recording
-     */
+    // durations are intentionally not recorded for WebSocket requests, mirroring sttp's own
+    // PrometheusBackend: the measured time would cover the whole socket lifetime rather than
+    // a request-response roundtrip
+    private def recordDuration(
+      request: GenericRequest[?, ?],
+      outcome: Either[Throwable, ResponseMetadata],
+      elapsed: F[FiniteDuration],
+    ): F[Unit] =
+      if (request.isWebSocket) unit
+      else
+        durationMapper(request, outcome).fold(unit) { histogram =>
+          elapsed.flatMap { elapsed => histogram.observe(elapsed.toUnit(SECONDS)) }
+        }
+
+    // metric recording must never fail the request: when the effect type can handle errors
+    // (which holds for every practical F, e.g. IO), individual metric failures are discarded
+    // and the remaining metrics are still recorded; a MonadThrow constraint would express this
+    // in the signature, but adding it would break binary compatibility of the released API
+    private val discardFailure: F[Unit] => F[Unit] =
+      Monad[F] match {
+        case monadError: MonadError[F, Any] @unchecked => effect => monadError.handleError(effect)(_ => ())
+        case _ => identity
+      }
+
+    private def recordAll(effects: F[Unit]*): F[Unit] =
+      effects.toList.traverse_(discardFailure)
+
+    private def recordOnce(state: State[F])(record: => F[Unit]): F[Unit] =
+      unit.flatMap { _ =>
+        if (state.recorded.compareAndSet(false, true)) record else unit
+      }
+
     private def captureResponseMetrics(
       request: GenericRequest[?, ?],
       response: ResponseMetadata,
       state: State[F],
     ): F[Unit] = {
-      val responseSizeEffect = for {
+      val responseSize = for {
         size <- response.contentLength.map(_.toDouble)
         summary <- responseSizeMapper(request, response)
       } yield summary.observe(size)
 
-      val counter = if (response.isSuccess) {
-        successMapper(request, response)
-      } else {
-        errorMapper(request, response)
-      }
+      val counterMapper = if (response.isSuccess) successMapper else errorMapper
 
-      for {
-        _ <- state.recordDuration
-        _ <- state.decActive
-        _ <- responseSizeEffect.getOrElse(Applicative[F].unit)
-        _ <- counter.fold(Applicative[F].unit)(_.inc())
-      } yield ()
+      recordAll(
+        state.recordDuration(response.asRight),
+        state.decActive,
+        responseSize.getOrElse(unit),
+        counterMapper(request, response).fold(unit)(_.inc()),
+      )
     }
 
-    /**
-     * Called when the response body has been received.
-     *
-     * @param request
-     *   The HTTP request that was sent
-     * @param response
-     *   The HTTP response metadata
-     * @param state
-     *   State containing cleanup effects from before
-     * @return
-     *   Note that this method must run any effects immediately, as it returns a `Unit`, without the
-     *   `F` wrapper.
-     */
     override def responseBodyReceived(
       request: GenericRequest[?, ?],
       response: ResponseMetadata,
       state: State[F],
-    ): Unit = {
-      ToTry[F].apply(captureResponseMetrics(request, response, state))
-      ()
-    }
+    ): Unit =
+      // the listener contract forces a synchronous signature here, so the effect is run via ToTry;
+      // the resulting Try is discarded as captureResponseMetrics already handles metric failures
+      if (state.recorded.compareAndSet(false, true)) {
+        val _ = ToTry[F].apply(captureResponseMetrics(request, response, state))
+      }
 
-    /**
-     * Called when the response has been handled (including WebSocket requests).
-     *
-     * @param request
-     *   The HTTP request that was sent
-     * @param response
-     *   The HTTP response metadata
-     * @param state
-     *   State containing cleanup effects from before
-     * @param e
-     *   Optional exception if response handling failed
-     * @return
-     *   Effect completing the metric recording
-     */
+    // fallback for requests where responseBodyReceived never fires: WebSockets, response
+    // exceptions raised before the body was received, and streaming bodies that are never
+    // fully consumed
     override def responseHandled(
       request: GenericRequest[?, ?],
       response: ResponseMetadata,
       state: State[F],
       e: Option[ResponseException[?]],
     ): F[Unit] =
-      captureResponseMetrics(request, response, state).whenA(request.isWebSocket)
+      recordOnce(state) {
+        captureResponseMetrics(request, response, state)
+      }
 
-    /**
-     * Called when a request throws an exception.
-     *
-     * @param request
-     *   The HTTP request that failed
-     * @param state
-     *   State containing cleanup effects from before
-     * @param e
-     *   The exception that was thrown
-     * @param responseBodyReceivedCalled
-     *   Whether responseBodyReceived was already called
-     * @return
-     *   Effect completing the metric recording
-     */
     override def exception(
       request: GenericRequest[?, ?],
       state: State[F],
       e: Throwable,
       responseBodyReceivedCalled: Boolean,
-    ): F[Unit] = {
-      val record = for {
-        _ <- state.recordDuration
-        _ <- state.decActive
-        _ <- failureMapper(request, e).fold(Applicative[F].unit)(_.inc())
-      } yield ()
-      record.whenA(!responseBodyReceivedCalled)
-    }
+    ): F[Unit] =
+      recordOnce(state) {
+        recordAll(
+          state.recordDuration(e.asLeft),
+          state.decActive,
+          failureMapper(request, e).fold(unit)(_.inc()),
+        )
+      }
   }
 }

--- a/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
+++ b/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
@@ -51,7 +51,7 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  * val backend: Backend[IO] = ???
  * val registry: CollectorRegistry[IO] = ???
  *
- * SmetricsBackend.default(backend, registry).use { backend => ??? }
+ * SmetricsBackend.default1(backend, registry).use { backend => ??? }
  * }}}
  *
  * ==Custom Metric Prefixes==
@@ -59,7 +59,7 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  * You can customize the metric name prefix:
  *
  * {{{
- * SmetricsBackend.default(backend, registry, prefix = Some("myapp_"))
+ * SmetricsBackend.default1(backend, registry, prefix = Some("myapp_"))
  * }}}
  *
  * This will generate metrics like:
@@ -237,7 +237,7 @@ object SmetricsBackend {
    * @return
    *   A new backend that records metrics according to the provided mappers
    */
-  def apply[F[_]: Clock: Monad: ToTry](
+  def apply[F[_]: Clock: MonadThrow: ToTry](
     delegate: Backend[F],
     durationMapper: (GenericRequest[?, ?], Either[Throwable, ResponseMetadata]) => Option[Histogram[F]],
     activeMapper: GenericRequest[?, ?] => Option[Gauge[F]],
@@ -259,12 +259,13 @@ object SmetricsBackend {
           failureMapper = failureMapper,
           requestSizeMapper = requestSizeMapper,
           responseSizeMapper = responseSizeMapper,
+          discardFailure = discardMetricFailure,
         ),
       ),
     )
   }
 
-  def apply[F[_]: Clock: Monad: ToTry, C](
+  def apply[F[_]: Clock: MonadThrow: ToTry, C](
     delegate: StreamBackend[F, C],
     durationMapper: (GenericRequest[?, ?], Either[Throwable, ResponseMetadata]) => Option[Histogram[F]],
     activeMapper: GenericRequest[?, ?] => Option[Gauge[F]],
@@ -286,6 +287,7 @@ object SmetricsBackend {
           failureMapper = failureMapper,
           requestSizeMapper = requestSizeMapper,
           responseSizeMapper = responseSizeMapper,
+          discardFailure = discardMetricFailure,
         ),
       ),
     )
@@ -293,7 +295,9 @@ object SmetricsBackend {
 
   /**
    * Binary-compatible predecessor of the outcome-aware overload, kept for released API
-   * compatibility.
+   * compatibility. Unlike that overload, it cannot isolate failures of individual metric effects
+   * (that requires `MonadThrow`, which this method cannot demand without breaking binary
+   * compatibility).
    */
   @deprecated("Use the overload with an outcome-aware durationMapper", "2.4.6")
   def apply[F[_]: Clock: Monad: ToTry](
@@ -305,23 +309,32 @@ object SmetricsBackend {
     failureMapper: (GenericRequest[?, ?], Throwable) => Option[Counter[F]],
     requestSizeMapper: GenericRequest[?, ?] => Option[Summary[F]],
     responseSizeMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Summary[F]],
-  ): Backend[F] =
-    apply(
-      delegate = delegate,
-      durationMapper = {
-        (request: GenericRequest[?, ?], _: Either[Throwable, ResponseMetadata]) => durationMapper(request)
-      },
-      activeMapper = activeMapper,
-      successMapper = successMapper,
-      errorMapper = errorMapper,
-      failureMapper = failureMapper,
-      requestSizeMapper = requestSizeMapper,
-      responseSizeMapper = responseSizeMapper,
+  ): Backend[F] = {
+    // redirects should be handled before metrics collection
+    FollowRedirectsBackend(
+      ListenerBackend(
+        delegate = delegate,
+        listener = new SmetricsListener[F](
+          durationMapper = {
+            (request: GenericRequest[?, ?], _: Either[Throwable, ResponseMetadata]) => durationMapper(request)
+          },
+          activeMapper = activeMapper,
+          successMapper = successMapper,
+          errorMapper = errorMapper,
+          failureMapper = failureMapper,
+          requestSizeMapper = requestSizeMapper,
+          responseSizeMapper = responseSizeMapper,
+          discardFailure = identity,
+        ),
+      ),
     )
+  }
 
   /**
    * Binary-compatible predecessor of the outcome-aware overload, kept for released API
-   * compatibility.
+   * compatibility. Unlike that overload, it cannot isolate failures of individual metric effects
+   * (that requires `MonadThrow`, which this method cannot demand without breaking binary
+   * compatibility).
    */
   @deprecated("Use the overload with an outcome-aware durationMapper", "2.4.6")
   def apply[F[_]: Clock: Monad: ToTry, C](
@@ -333,19 +346,26 @@ object SmetricsBackend {
     failureMapper: (GenericRequest[?, ?], Throwable) => Option[Counter[F]],
     requestSizeMapper: GenericRequest[?, ?] => Option[Summary[F]],
     responseSizeMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Summary[F]],
-  ): StreamBackend[F, C] =
-    apply(
-      delegate = delegate,
-      durationMapper = {
-        (request: GenericRequest[?, ?], _: Either[Throwable, ResponseMetadata]) => durationMapper(request)
-      },
-      activeMapper = activeMapper,
-      successMapper = successMapper,
-      errorMapper = errorMapper,
-      failureMapper = failureMapper,
-      requestSizeMapper = requestSizeMapper,
-      responseSizeMapper = responseSizeMapper,
+  ): StreamBackend[F, C] = {
+    // redirects should be handled before metrics collection
+    FollowRedirectsBackend(
+      ListenerBackend(
+        delegate = delegate,
+        listener = new SmetricsListener[F](
+          durationMapper = {
+            (request: GenericRequest[?, ?], _: Either[Throwable, ResponseMetadata]) => durationMapper(request)
+          },
+          activeMapper = activeMapper,
+          successMapper = successMapper,
+          errorMapper = errorMapper,
+          failureMapper = failureMapper,
+          requestSizeMapper = requestSizeMapper,
+          responseSizeMapper = responseSizeMapper,
+          discardFailure = identity,
+        ),
+      ),
     )
+  }
 
   /**
    * Creates an STTP backend with automatic metric collection using a CollectorRegistry.
@@ -376,7 +396,7 @@ object SmetricsBackend {
    * val backend: Backend[IO] = ???
    * val registry: CollectorRegistry[IO] = ???
    *
-   * SmetricsBackend.default(backend, registry, prefix = Some("myapp_")).use { metricsBackend =>
+   * SmetricsBackend.default1(backend, registry, prefix = Some("myapp_")).use { metricsBackend =>
    *   basicRequest
    *     .get(uri"https://api.example.com/users")
    *     .send(metricsBackend)
@@ -394,13 +414,53 @@ object SmetricsBackend {
    * @return
    *   A Resource that manages the metrics-enabled backend lifecycle
    */
+  def default1[F[_]: Clock: MonadThrow: ToTry](
+    delegate: Backend[F],
+    collectorRegistry: CollectorRegistry[F],
+    prefix: Option[String] = None,
+  ): Resource[F, Backend[F]] = {
+    val registry = prefix.fold(collectorRegistry)(collectorRegistry.prefixed(_))
+    makeDefaultSmetricsListener(registry, discardMetricFailure).map { listener =>
+      FollowRedirectsBackend(
+        ListenerBackend(
+          delegate,
+          listener,
+        ),
+      )
+    }
+  }
+
+  def default1[F[_]: Clock: MonadThrow: ToTry, C](
+    delegate: StreamBackend[F, C],
+    collectorRegistry: CollectorRegistry[F],
+    prefix: Option[String],
+  ): Resource[F, StreamBackend[F, C]] = {
+    val registry = prefix.fold(collectorRegistry)(collectorRegistry.prefixed(_))
+    makeDefaultSmetricsListener(registry, discardMetricFailure).map { listener =>
+      FollowRedirectsBackend(
+        ListenerBackend(
+          delegate,
+          listener,
+        ),
+      )
+    }
+  }
+
+  /**
+   * Binary-compatible predecessor of [[default1]], kept for released API compatibility. Unlike
+   * [[default1]], it cannot isolate failures of individual metric effects: that requires
+   * `MonadThrow`, which this method cannot demand without breaking binary compatibility, and a
+   * `MonadThrow` overload under the same name would make every existing call site ambiguous
+   * (overloads differing only in implicit parameters cannot be resolved).
+   */
+  @deprecated("Use default1, which also isolates metric recording failures", "2.4.6")
   def default[F[_]: Clock: Monad: ToTry](
     delegate: Backend[F],
     collectorRegistry: CollectorRegistry[F],
     prefix: Option[String] = None,
   ): Resource[F, Backend[F]] = {
     val registry = prefix.fold(collectorRegistry)(collectorRegistry.prefixed(_))
-    makeDefaultSmetricsListener(registry).map { listener =>
+    makeDefaultSmetricsListener(registry, identity[F[Unit]]).map { listener =>
       FollowRedirectsBackend(
         ListenerBackend(
           delegate,
@@ -410,13 +470,21 @@ object SmetricsBackend {
     }
   }
 
+  /**
+   * Binary-compatible predecessor of [[default1]], kept for released API compatibility. Unlike
+   * [[default1]], it cannot isolate failures of individual metric effects: that requires
+   * `MonadThrow`, which this method cannot demand without breaking binary compatibility, and a
+   * `MonadThrow` overload under the same name would make every existing call site ambiguous
+   * (overloads differing only in implicit parameters cannot be resolved).
+   */
+  @deprecated("Use default1, which also isolates metric recording failures", "2.4.6")
   def default[F[_]: Clock: Monad: ToTry, C](
     delegate: StreamBackend[F, C],
     collectorRegistry: CollectorRegistry[F],
     prefix: Option[String],
   ): Resource[F, StreamBackend[F, C]] = {
     val registry = prefix.fold(collectorRegistry)(collectorRegistry.prefixed(_))
-    makeDefaultSmetricsListener(registry).map { listener =>
+    makeDefaultSmetricsListener(registry, identity[F[Unit]]).map { listener =>
       FollowRedirectsBackend(
         ListenerBackend(
           delegate,
@@ -426,8 +494,14 @@ object SmetricsBackend {
     }
   }
 
+  // metric recording must never fail the request, hence individual metric failures are
+  // discarded and the remaining metrics are still recorded
+  private def discardMetricFailure[F[_]: MonadThrow]: F[Unit] => F[Unit] =
+    _.handleError(_ => ())
+
   private def makeDefaultSmetricsListener[F[_]: Clock: Monad: ToTry](
     collectorRegistry: CollectorRegistry[F],
+    discardFailure: F[Unit] => F[Unit],
   ): Resource[F, SmetricsListener[F]] =
     for {
       duration <- collectorRegistry.histogram(
@@ -476,6 +550,7 @@ object SmetricsBackend {
       failureMapper = { (req, _) => failure.labels(methodLabel(req)).some },
       requestSizeMapper = { req => requestSize.labels(methodLabel(req)).some },
       responseSizeMapper = { (req, rsp) => responseSize.labels(methodLabel(req), statusLabel(rsp)).some },
+      discardFailure = discardFailure,
     )
 
   /**
@@ -519,6 +594,10 @@ object SmetricsBackend {
     failureMapper: (GenericRequest[?, ?], Throwable) => Option[Counter[F]],
     requestSizeMapper: GenericRequest[?, ?] => Option[Summary[F]],
     responseSizeMapper: (GenericRequest[?, ?], ResponseMetadata) => Option[Summary[F]],
+    // how to handle a failing metric effect: [[discardMetricFailure]] for the MonadThrow-based
+    // entry points, identity (failures propagate, pre-2.4.6 behavior) for the released
+    // Monad-based ones which cannot demand MonadThrow without breaking binary compatibility
+    discardFailure: F[Unit] => F[Unit],
   ) extends RequestListener[F, State[F]] {
 
     private val unit = Applicative[F].unit
@@ -555,16 +634,6 @@ object SmetricsBackend {
         durationMapper(request, outcome).fold(unit) { histogram =>
           elapsed.flatMap { elapsed => histogram.observe(elapsed.toUnit(SECONDS)) }
         }
-
-    // metric recording must never fail the request: when the effect type can handle errors
-    // (which holds for every practical F, e.g. IO), individual metric failures are discarded
-    // and the remaining metrics are still recorded; a MonadThrow constraint would express this
-    // in the signature, but adding it would break binary compatibility of the released API
-    private val discardFailure: F[Unit] => F[Unit] =
-      Monad[F] match {
-        case monadError: MonadError[F, Any] @unchecked => effect => monadError.handleError(effect)(_ => ())
-        case _ => identity
-      }
 
     private def recordAll(effects: F[Unit]*): F[Unit] =
       effects.toList.traverse_(discardFailure)

--- a/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
+++ b/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
@@ -88,6 +88,32 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  * )
  * }}}
  *
+ * ==Custom Recording==
+ *
+ * For example size mappers are typed as [[com.evolutiongaming.smetrics.Summary]], but using an actual
+ * summary collector is not mandatory: `Summary` has a single `observe` method, so any recording
+ * strategy can be plugged in by implementing it. For example, recording sizes as a histogram
+ *
+ * {{{
+ * def sizeAsHistogram(histogram: Histogram[F]): Summary[F] =
+ *   new Summary[F] {
+ *     def observe(value: Double): F[Unit] =
+ *       histogram.observe(value)
+ *   }
+ *
+ * val backend = SmetricsBackend(
+ *   delegate = underlyingBackend,
+ *   requestSizeMapper = { req =>
+ *     sizeAsHistogram(
+ *       requestSizeHistogram.labels(methodLabel(req))
+ *     ).some
+ *   },
+ *   ...
+ * )
+ * }}}
+ * 
+ * Returning `None` from a mapper disables that metric entirely.
+ *
  * ==Labels==
  *
  * By default, the following labels are attached to metrics:

--- a/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
+++ b/modules/sttp4/src/main/scala/sttp/client4/smetrics/SmetricsBackend.scala
@@ -90,9 +90,10 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  *
  * ==Custom Recording==
  *
- * For example size mappers are typed as [[com.evolutiongaming.smetrics.Summary]], but using an actual
- * summary collector is not mandatory: `Summary` has a single `observe` method, so any recording
- * strategy can be plugged in by implementing it. For example, recording sizes as a histogram
+ * For example, size mappers are typed as [[com.evolutiongaming.smetrics.Summary]], but using an
+ * actual summary collector is not mandatory: `Summary` has a single `observe` method, so any
+ * recording strategy can be plugged in by implementing it. For example, recording sizes as a
+ * histogram:
  *
  * {{{
  * def sizeAsHistogram(histogram: Histogram[F]): Summary[F] =
@@ -111,8 +112,22 @@ import scala.concurrent.duration.{FiniteDuration, SECONDS}
  *   ...
  * )
  * }}}
- * 
+ *
  * Returning `None` from a mapper disables that metric entirely.
+ *
+ * ==Success, Error and Failure Counters==
+ *
+ * The success and error counters reflect the HTTP-level outcome, i.e. the response status code: a
+ * response that is received successfully but fails during body handling (e.g. deserialization) is
+ * still counted by its status code. The failure counter only tracks requests that produced no
+ * response metadata at all (connection errors, timeouts, cancellation).
+ *
+ * ==Streaming Responses==
+ *
+ * For `...Unsafe` response descriptions (e.g. `asStreamUnsafe`), metrics are recorded when the
+ * response is handled, before the body is consumed: the duration reflects time to response handling
+ * rather than time to body completion. This is a deliberate trade-off that keeps the
+ * active-requests gauge accurate even when a streamed body is never fully consumed.
  *
  * ==Labels==
  *
@@ -325,7 +340,7 @@ object SmetricsBackend {
    * (that requires `MonadThrow`, which this method cannot demand without breaking binary
    * compatibility).
    */
-  @deprecated("Use the overload with an outcome-aware durationMapper", "2.4.6")
+  @deprecated("Use the overload with an outcome-aware durationMapper", "2.5.0")
   def apply[F[_]: Clock: Monad: ToTry](
     delegate: Backend[F],
     durationMapper: GenericRequest[?, ?] => Option[Histogram[F]],
@@ -362,7 +377,7 @@ object SmetricsBackend {
    * (that requires `MonadThrow`, which this method cannot demand without breaking binary
    * compatibility).
    */
-  @deprecated("Use the overload with an outcome-aware durationMapper", "2.4.6")
+  @deprecated("Use the overload with an outcome-aware durationMapper", "2.5.0")
   def apply[F[_]: Clock: Monad: ToTry, C](
     delegate: StreamBackend[F, C],
     durationMapper: GenericRequest[?, ?] => Option[Histogram[F]],
@@ -479,7 +494,7 @@ object SmetricsBackend {
    * `MonadThrow` overload under the same name would make every existing call site ambiguous
    * (overloads differing only in implicit parameters cannot be resolved).
    */
-  @deprecated("Use default1, which also isolates metric recording failures", "2.4.6")
+  @deprecated("Use default1, which also isolates metric recording failures", "2.5.0")
   def default[F[_]: Clock: Monad: ToTry](
     delegate: Backend[F],
     collectorRegistry: CollectorRegistry[F],
@@ -503,7 +518,7 @@ object SmetricsBackend {
    * `MonadThrow` overload under the same name would make every existing call site ambiguous
    * (overloads differing only in implicit parameters cannot be resolved).
    */
-  @deprecated("Use default1, which also isolates metric recording failures", "2.4.6")
+  @deprecated("Use default1, which also isolates metric recording failures", "2.5.0")
   def default[F[_]: Clock: Monad: ToTry, C](
     delegate: StreamBackend[F, C],
     collectorRegistry: CollectorRegistry[F],
@@ -596,10 +611,10 @@ object SmetricsBackend {
   private[this] final case class State[F[_]](
     recordDuration: Either[Throwable, ResponseMetadata] => F[Unit],
     decActive: F[Unit],
-    // AtomicBoolean instead of Ref[F, Boolean]: creating a Ref requires a Sync/Ref.Make constraint,
-    // which cannot be added without breaking binary compatibility of the released API; if bin-compat
-    // constraints are ever dropped (e.g. in a 3.0), Ref[F, Boolean] + getAndSet would be the
-    // idiomatic replacement
+    // AtomicBoolean instead of Ref[F, Boolean]: creating a Ref requires a
+    // Sync/Ref.Make constraint, which cannot be added without breaking binary compatibility of
+    // the released API; if bin-compat constraints are ever dropped (e.g. in a 3.0),
+    // Ref[F, Boolean] + getAndSet would be the idiomatic replacement
     recorded: AtomicBoolean,
   )
 
@@ -607,9 +622,12 @@ object SmetricsBackend {
    * Internal RequestListener implementation that records metrics for HTTP requests.
    *
    * Metrics are recorded exactly once per request, by whichever completion hook fires first:
-   *   - `responseBodyReceived` for safe, non-WebSocket requests whose body was fully received
-   *   - `responseHandled` as the fallback for WebSockets, response exceptions raised before the
-   *     body was received, and streaming bodies that are never fully consumed
+   *   - `responseBodyReceived` for safe, non-WebSocket requests: it fires once the body is fully
+   *     received, so their duration is measured to body completion
+   *   - `responseHandled` for WebSockets, response exceptions raised before the body was received,
+   *     and all `...Unsafe` response descriptions, where it fires before `responseBodyReceived`
+   *     (which may never fire for an unconsumed stream): their duration is measured to response
+   *     handling, trading streaming-duration accuracy for a leak-free active gauge
    *   - `exception` for requests that failed without response metadata (including cancellation)
    */
   private[this] class SmetricsListener[F[_]: Clock: Monad: ToTry](
@@ -700,9 +718,10 @@ object SmetricsBackend {
         val _ = ToTry[F].apply(captureResponseMetrics(request, response, state))
       }
 
-    // fallback for requests where responseBodyReceived never fires: WebSockets, response
-    // exceptions raised before the body was received, and streaming bodies that are never
-    // fully consumed
+    // the primary recording path for WebSockets, response exceptions raised before the body was
+    // received, and `...Unsafe` response descriptions (where this hook fires before
+    // responseBodyReceived, which may never fire for an unconsumed stream); a no-op when
+    // responseBodyReceived already recorded
     override def responseHandled(
       request: GenericRequest[?, ?],
       response: ResponseMetadata,

--- a/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
@@ -172,7 +172,11 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
         events.size shouldBe 6
         events.count(event => event.name == MetricNames.active && event.op == "dec") shouldBe 1
         events.count(event => event.name == MetricNames.duration && event.op == "observe") shouldBe 1
-        events.count(event => event.metricType == "counter") shouldBe 1
+        // counters reflect the HTTP-level outcome: the response itself was a 2xx, so the body
+        // handling failure is counted as a success, not as an error or failure
+        events.collect {
+          case MetricEvent(MetricNames.success, "counter", List("POST", "2xx"), "inc", 1.0) => ()
+        }.size shouldBe 1
       }
     }.run()
   }
@@ -352,6 +356,38 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
       } yield withClue(finalEvents) {
         activeOps(finalEvents, "inc") shouldBe requestsNumber
         activeOps(finalEvents, "dec") shouldBe requestsNumber
+      }
+    }
+  }
+
+  test("cancelled request decrements the active gauge and counts a failure") {
+    def awaitActiveInc(registry: InMemoryCollectorRegistry): IO[Unit] =
+      registry.events.flatMap { events =>
+        if (events.exists(event => event.name == MetricNames.active && event.op == "inc")) IO.unit
+        else IO.sleep(10.millis) >> awaitActiveInc(registry)
+      }
+
+    runIO {
+      for {
+        gate <- Deferred[IO, Unit]
+        registry <- InMemoryCollectorRegistry.make
+        stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest
+          .thenRespondF(gate.get.as(ResponseStub.adjust("", StatusCode.Ok)))
+        backendAllocated <- SmetricsBackend.default1(stubBackend, registry).allocated
+        (backend, release) = backendAllocated
+        fiber <- basicRequest.get(`/`).send(backend).start
+        _ <- awaitActiveInc(registry)
+        _ <- fiber.cancel
+        events <- registry.events
+        _ <- release
+      } yield withClue(events) {
+        events.size shouldBe 4
+        events.count(event => event.name == MetricNames.active && event.op == "inc") shouldBe 1
+        events.count(event => event.name == MetricNames.active && event.op == "dec") shouldBe 1
+        events.count(event => event.name == MetricNames.duration && event.op == "observe") shouldBe 1
+        events.collect {
+          case MetricEvent(MetricNames.failure, "counter", List("GET"), "inc", 1.0) => ()
+        }.size shouldBe 1
       }
     }
   }

--- a/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
@@ -9,13 +9,15 @@ import com.evolutiongaming.smetrics.*
 import com.evolutiongaming.smetrics.IOSuite.*
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
+import sttp.capabilities.Effect
 import sttp.client4.*
+import sttp.client4.ResponseException.{DeserializationException, UnexpectedStatusCode}
 import sttp.client4.impl.cats.implicits.*
 import sttp.client4.smetrics.SmetricsBackend.{DefaultBuckets, MetricNames, methodLabel, statusLabel}
 import sttp.client4.smetrics.SmetricsBackendSpec.*
 import sttp.client4.testing.BackendStub
 import sttp.client4.testing.ResponseStub
-import sttp.model.{Header, StatusCode}
+import sttp.model.{Header, ResponseMetadata, StatusCode}
 
 class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
 
@@ -136,6 +138,122 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
         case MetricEvent("http_client_requests_failure", "counter", List("POST"), "inc", 1.0) => 5
       } shouldBe List(1, 2, 3, 4, 5)
     }.run()
+  }
+
+  test("deserialization failure after body received records metrics exactly once") {
+    collect(
+      stub =>
+        stub.whenAnyRequest
+          .thenRespond(
+            ResponseStub.adjust(
+              body = html,
+              code = StatusCode.Ok,
+            ).withContentLength(html.length.toLong),
+          ),
+      backend =>
+        basicRequest
+          .post(`/`)
+          .body(body)
+          .response {
+            asString.map[Either[String, String]] { _ =>
+              throw DeserializationException(
+                "Unknown body",
+                new Exception("Unable to parse"),
+                ResponseMetadata(StatusCode.Ok, "OK", Nil),
+              )
+            }
+          }
+          .send(backend)
+          .attempt,
+    ).map { events =>
+      withClue(events) {
+        events.size shouldBe 6
+        events.count(event => event.name == MetricNames.active && event.op == "dec") shouldBe 1
+        events.count(event => event.name == MetricNames.duration && event.op == "observe") shouldBe 1
+        events.count(event => event.metricType == "counter") shouldBe 1
+      }
+    }.run()
+  }
+
+  test("response exception without received body still records metrics") {
+    collect(
+      stub =>
+        stub.whenAnyRequest
+          .thenThrow(
+            UnexpectedStatusCode("not found", ResponseMetadata(StatusCode.NotFound, "Not Found", Nil)),
+          ),
+      backend => basicRequest.post(`/`).body(body).send(backend).attempt,
+    ).map { events =>
+      withClue(events) {
+        events.count(event => event.name == MetricNames.active && event.op == "dec") shouldBe 1
+        events.count(event => event.name == MetricNames.duration && event.op == "observe") shouldBe 1
+        events.collect {
+          case MetricEvent(MetricNames.error, "counter", List("POST", "4xx"), "inc", 1.0) => ()
+        }.size shouldBe 1
+      }
+    }.run()
+  }
+
+  test("streaming response with body never received still decrements the active gauge") {
+    runIO {
+      // Models a real backend serving an `asStreamUnsafe(...)` response: `send` completes when the
+      // headers arrive, and the `onBodyReceived` callback fires only if the caller fully consumes
+      // the stream - which here never happens.
+      val bodyNeverReceivedBackend: Backend[IO] = new Backend[IO] {
+        override val monad: sttp.monad.MonadError[IO] = sttp.monad.MonadError[IO]
+        override def send[T](request: GenericRequest[T, Any with Effect[IO]]): IO[Response[T]] =
+          IO.pure(ResponseStub.exact("streamed body, never consumed").asInstanceOf[Response[T]])
+        override def close(): IO[Unit] = IO.unit
+      }
+
+      for {
+        registry <- InMemoryCollectorRegistry.make
+        backendAllocated <- SmetricsBackend.default(bodyNeverReceivedBackend, registry).allocated
+        (backend, release) = backendAllocated
+        _ <- basicRequest.get(`/`).send(backend)
+        events <- registry.events
+        _ <- release
+      } yield withClue(events) {
+        events.count(event => event.name == MetricNames.active && event.op == "dec") shouldBe 1
+        events.count(event => event.name == MetricNames.duration && event.op == "observe") shouldBe 1
+      }
+    }
+  }
+
+  test("gauge decrement is not lost when duration recording fails") {
+    runIO {
+      val stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest.thenRespondOk()
+
+      val failingDuration: Histogram[IO] = new Histogram[IO] {
+        override def observe(value: Double): IO[Unit] =
+          IO.raiseError(new RuntimeException("metrics store unavailable"))
+      }
+
+      val resource = for {
+        registry <- InMemoryCollectorRegistry.make.toResource
+        active <- registry.gauge(
+          name = MetricNames.active,
+          help = "Number of active requests",
+          labels = LabelNames("method"),
+        )
+        backend = SmetricsBackend(
+          stubBackend,
+          durationMapper = { _ => failingDuration.some },
+          activeMapper = { req => active.labels(methodLabel(req)).some },
+          successMapper = { (_, _) => Option.empty[Counter[IO]] },
+          errorMapper = { (_, _) => Option.empty[Counter[IO]] },
+          failureMapper = { (_, _) => Option.empty[Counter[IO]] },
+          requestSizeMapper = { _ => Option.empty[Summary[IO]] },
+          responseSizeMapper = { (_, _) => Option.empty[Summary[IO]] },
+        )
+        _ <- basicRequest.get(`/`).send(backend).toResource
+        events <- registry.events.toResource
+      } yield withClue(events) {
+        events.count(event => event.name == MetricNames.active && event.op == "dec") shouldBe 1
+      }
+
+      resource.use(_.pure[IO])
+    }
   }
 
   test("configure prefix") {

--- a/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
@@ -34,7 +34,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
     for {
       registry <- InMemoryCollectorRegistry.make
       backendAllocated <- SmetricsBackend
-        .default(
+        .default1(
           stub(BackendStub[IO](sttp.monad.MonadError[IO])),
           registry,
         )
@@ -208,7 +208,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
 
       for {
         registry <- InMemoryCollectorRegistry.make
-        backendAllocated <- SmetricsBackend.default(bodyNeverReceivedBackend, registry).allocated
+        backendAllocated <- SmetricsBackend.default1(bodyNeverReceivedBackend, registry).allocated
         (backend, release) = backendAllocated
         _ <- basicRequest.get(`/`).send(backend)
         events <- registry.events
@@ -299,7 +299,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
       for {
         registry <- InMemoryCollectorRegistry.make
         backendAllocated <- SmetricsBackend
-          .default(
+          .default1(
             stubBackend,
             registry,
             prefix = Some("prefix_"),

--- a/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
@@ -19,6 +19,8 @@ import sttp.client4.testing.BackendStub
 import sttp.client4.testing.ResponseStub
 import sttp.model.{Header, ResponseMetadata, StatusCode}
 
+import scala.concurrent.duration.*
+
 class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
 
   implicit val tt: ToTry[IO] = ToTry.ioToTry
@@ -289,6 +291,68 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
       }
 
       resource.use(_.pure[IO])
+    }
+  }
+
+  test("mappers returning None disable all metrics") {
+    runIO {
+      val stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest.thenRespondOk()
+
+      for {
+        registry <- InMemoryCollectorRegistry.make
+        backend = SmetricsBackend(
+          stubBackend,
+          durationMapper = { (_, _) => Option.empty[Histogram[IO]] },
+          activeMapper = { _ => Option.empty[Gauge[IO]] },
+          successMapper = { (_, _) => Option.empty[Counter[IO]] },
+          errorMapper = { (_, _) => Option.empty[Counter[IO]] },
+          failureMapper = { (_, _) => Option.empty[Counter[IO]] },
+          requestSizeMapper = { _ => Option.empty[Summary[IO]] },
+          responseSizeMapper = { (_, _) => Option.empty[Summary[IO]] },
+        )
+        response <- basicRequest.post(`/`).body(body).send(backend)
+        events <- registry.events
+      } yield {
+        response.code shouldBe StatusCode.Ok
+        events shouldBe empty
+      }
+    }
+  }
+
+  test("active gauge reflects in-flight requests under concurrency") {
+    val requestsNumber = 5
+
+    def activeOps(events: Vector[MetricEvent], op: String): Int =
+      events.count(event => event.name == MetricNames.active && event.op == op)
+
+    def awaitInFlight(registry: InMemoryCollectorRegistry, expected: Int): IO[Vector[MetricEvent]] =
+      registry.events.flatMap { events =>
+        if (activeOps(events, "inc") >= expected) IO.pure(events)
+        else IO.sleep(10.millis) >> awaitInFlight(registry, expected)
+      }
+
+    runIO {
+      for {
+        gate <- Deferred[IO, Unit]
+        registry <- InMemoryCollectorRegistry.make
+        stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest
+          .thenRespondF(gate.get.as(ResponseStub.adjust("", StatusCode.Ok)))
+        backendAllocated <- SmetricsBackend.default1(stubBackend, registry).allocated
+        (backend, release) = backendAllocated
+        fibers <- basicRequest.get(`/`).send(backend).start.replicateA(requestsNumber)
+        inFlightEvents <- awaitInFlight(registry, requestsNumber)
+        _ = withClue(inFlightEvents) {
+          activeOps(inFlightEvents, "inc") shouldBe requestsNumber
+          activeOps(inFlightEvents, "dec") shouldBe 0
+        }
+        _ <- gate.complete(())
+        _ <- fibers.traverse_(_.join)
+        finalEvents <- registry.events
+        _ <- release
+      } yield withClue(finalEvents) {
+        activeOps(finalEvents, "inc") shouldBe requestsNumber
+        activeOps(finalEvents, "dec") shouldBe requestsNumber
+      }
     }
   }
 

--- a/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
@@ -220,6 +220,42 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
     }
   }
 
+  test("duration histogram can be labelled by response status") {
+    runIO {
+      val stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest.thenRespondNotFound()
+
+      val resource = for {
+        registry <- InMemoryCollectorRegistry.make.toResource
+        duration <- registry.histogram(
+          name = MetricNames.duration,
+          help = "Request duration in seconds",
+          buckets = Buckets(NonEmptyList.fromListUnsafe(DefaultBuckets)),
+          labels = LabelNames("method", "status"),
+        )
+        backend = SmetricsBackend(
+          stubBackend,
+          durationMapper = { (req, outcome) =>
+            duration.labels(methodLabel(req), outcome.fold(_ => "failure", statusLabel)).some
+          },
+          activeMapper = { _ => Option.empty[Gauge[IO]] },
+          successMapper = { (_, _) => Option.empty[Counter[IO]] },
+          errorMapper = { (_, _) => Option.empty[Counter[IO]] },
+          failureMapper = { (_, _) => Option.empty[Counter[IO]] },
+          requestSizeMapper = { _ => Option.empty[Summary[IO]] },
+          responseSizeMapper = { (_, _) => Option.empty[Summary[IO]] },
+        )
+        _ <- basicRequest.get(`/`).send(backend).toResource
+        events <- registry.events.toResource
+      } yield withClue(events) {
+        events.collect {
+          case MetricEvent(MetricNames.duration, "histogram", List("GET", "4xx"), "observe", _) => ()
+        }.size shouldBe 1
+      }
+
+      resource.use(_.pure[IO])
+    }
+  }
+
   test("gauge decrement is not lost when duration recording fails") {
     runIO {
       val stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest.thenRespondOk()
@@ -238,7 +274,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
         )
         backend = SmetricsBackend(
           stubBackend,
-          durationMapper = { _ => failingDuration.some },
+          durationMapper = { (_, _) => failingDuration.some },
           activeMapper = { req => active.labels(methodLabel(req)).some },
           successMapper = { (_, _) => Option.empty[Counter[IO]] },
           errorMapper = { (_, _) => Option.empty[Counter[IO]] },
@@ -341,7 +377,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
 
         backend = SmetricsBackend(
           stubBackend,
-          durationMapper = { req =>
+          durationMapper = { (req, _) =>
             duration.labels(methodLabel(req), backendLabel, resourceLabel).some
           },
           activeMapper = { req =>

--- a/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
+++ b/modules/sttp4/src/test/scala/sttp/client4/smetrics/SmetricsBackendSpec.scala
@@ -2,6 +2,7 @@ package sttp.client4.smetrics
 
 import cats.data.NonEmptyList
 import cats.effect.*
+import cats.effect.std.Semaphore
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.ToTry
@@ -337,10 +338,10 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
 
     runIO {
       for {
-        gate <- Deferred[IO, Unit]
+        gate <- Semaphore[IO](0)
         registry <- InMemoryCollectorRegistry.make
         stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest
-          .thenRespondF(gate.get.as(ResponseStub.adjust("", StatusCode.Ok)))
+          .thenRespondF(gate.acquire.as(ResponseStub.adjust("", StatusCode.Ok)))
         backendAllocated <- SmetricsBackend.default1(stubBackend, registry).allocated
         (backend, release) = backendAllocated
         fibers <- basicRequest.get(`/`).send(backend).start.replicateA(requestsNumber)
@@ -349,7 +350,7 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
           activeOps(inFlightEvents, "inc") shouldBe requestsNumber
           activeOps(inFlightEvents, "dec") shouldBe 0
         }
-        _ <- gate.complete(())
+        _ <- gate.releaseN(requestsNumber.toLong)
         _ <- fibers.traverse_(_.join)
         finalEvents <- registry.events
         _ <- release
@@ -369,10 +370,9 @@ class SmetricsBackendSpec extends AsyncFunSuite with Matchers {
 
     runIO {
       for {
-        gate <- Deferred[IO, Unit]
         registry <- InMemoryCollectorRegistry.make
         stubBackend = BackendStub[IO](sttp.monad.MonadError[IO]).whenAnyRequest
-          .thenRespondF(gate.get.as(ResponseStub.adjust("", StatusCode.Ok)))
+          .thenRespondF(IO.never)
         backendAllocated <- SmetricsBackend.default1(stubBackend, registry).allocated
         (backend, release) = backendAllocated
         fiber <- basicRequest.get(`/`).send(backend).start


### PR DESCRIPTION
1. The sttp4 SmetricsBackend was ported from sttp's official PrometheusBackend and inherited a defect in how the listener lifecycle maps to metric recording: when a request ends in a ResponseException before the body is received (e.g. a decompression failure), or when a streaming response body is never fully consumed, no completion hook records anything. In production this means an http_client_requests_active gauge that only ever climbs. Every claim here is pinned by a test that was written first and failed against the old implementation, so the fixes address demonstrated defects, not review speculation.
2. One misbehaving metric could silently disable healthy ones. Metric-recording effects were sequenced as a single chain whose outcome was discarded, so a single failing user-supplied mapper cancelled the gauge decrement and duration recording queued behind it - invisibly, since the failure surfaced nowhere. Metric recording must never affect request processing, and one metric's failure must not take the others down with it, recording effects are now isolated from each other.
3. Users could not label durations by response status. Duration histograms were resolved from the request alone, before the outcome exists, making per-status latency (and error-ratio queries over histograms) inexpressible. Since the timer needs no labels to start - only the final observation does - resolving the histogram at observe time makes the API strictly more general at zero cost. For the same flexibility reason, the docs now spell out that the Summary-typed size mappers accept any custom implementation (it is a single-method interface), so consumers who don't want an actual summary collector can record sizes however they need - e.g. as a histogram plus a traffic counter - or disable a metric by returning None.
4. Behavioral notes made explicit. Durations are intentionally not recorded for WebSocket requests (a socket's lifetime is not a request-response roundtrip - same rationale as upstream); this was implicit in the code and is now documented. sttp3 received the same hardening and the same outcome-aware mapper for parity, so both modules evolve together.

The API shape follows from our binary-compatibility guarantee. This library promises binary-compatible releases, which forbids touching any released signature - including its implicit parameters. That is why new capability arrives as new entry points (default1, the outcome-aware apply overloads) while the old ones stay byte-identical, deprecated, and still receive the leak fix, failure isolation specifically requires MonadThrow, which the released Monad-based signatures cannot demand. The once-only recording guard is an AtomicBoolean rather than a Ref for the same reason: allocating a Ref would introduce a Make requirement, i.e. another binary break.