### PR TITLE
remove workaround for "-Wnonunit-statement"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,9 +37,6 @@ lazy val commonSettings = Seq(
     if3 = Nil,
     if2 = List(compilerPlugin(("org.typelevel" % "kind-projector" % "0.13.4").cross(CrossVersion.full))),
   ),
-  // -Wnonunit-statement (added in sbt-scalac-opts-plugin 0.1.0) flags ScalaTest's
-  // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
-  Test / scalacOptions -= "-Wnonunit-statement",
   // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
   // When a module's instrumented code runs inside another module's forked test JVM (before that
   // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by removing an obsolete test compiler warning override and its related comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->