### PR TITLE
Survive failed Prometheus registration in InstrumentedAppender

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,9 @@ lazy val logback = project
     libraryDependencies ++= Seq(
       Dependencies.PrometheusV1.core,
       Dependencies.Logback.classic,
+      Dependencies.weaver % Test,
     ),
+    testFrameworks += new TestFramework("weaver.framework.CatsEffect"),
     versionPolicyCheck / skip := true,
   )
 

--- a/modules/logback/src/main/scala/com/evolution/smetrics/logback/InstrumentedAppender.scala
+++ b/modules/logback/src/main/scala/com/evolution/smetrics/logback/InstrumentedAppender.scala
@@ -4,32 +4,83 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.UnsynchronizedAppenderBase
 import io.prometheus.metrics.core.metrics.Counter as PrometheusCounter
+import io.prometheus.metrics.model.registry.PrometheusRegistry
 
+/**
+ * Counts log statements per log level in the `logback_appender_total` Prometheus counter.
+ *
+ * The counter is registered once per JVM: logback re-creates appender instances on every
+ * configuration reload (`scan="true"`), while the Prometheus registry rejects duplicate
+ * registrations.
+ *
+ * A failed registration must not break logging: an `Error` escaping [[append]] would propagate
+ * through logback into the application code calling the logger, because logback catches only
+ * `Exception`. Hence the registration failure is kept as a value, reported to the logback status
+ * system on [[start]], and [[append]] becomes a no-op.
+ */
 class InstrumentedAppender extends UnsynchronizedAppenderBase[ILoggingEvent] {
 
+  private[logback] def counters: Either[Throwable, InstrumentedAppender.LevelCounters] =
+    InstrumentedAppender.defaultCounters
+
+  override def start(): Unit = {
+    counters.left.foreach { cause =>
+      addError(
+        "failed to register the logback_appender_total Prometheus counter, " +
+          "log level metrics will not be reported",
+        cause,
+      )
+    }
+    super.start()
+  }
+
   override protected def append(eventObject: ILoggingEvent): Unit =
-    eventObject.getLevel match {
-      case Level.TRACE => InstrumentedAppender.TraceCounter.inc()
-      case Level.DEBUG => InstrumentedAppender.DebugCounter.inc()
-      case Level.INFO => InstrumentedAppender.InfoCounter.inc()
-      case Level.WARN => InstrumentedAppender.WarnCounter.inc()
-      case Level.ERROR => InstrumentedAppender.ErrorCounter.inc()
-      case _ => ()
+    counters match {
+      case Right(levelCounters) => levelCounters.inc(eventObject.getLevel)
+      case Left(_) => ()
     }
 
 }
 
-private object InstrumentedAppender {
-  private val Counter =
-    PrometheusCounter
-      .builder()
-      .name("logback_appender_total")
-      .help("Logback log statements at various log levels")
-      .labelNames("level")
-      .register()
-  private val TraceCounter = Counter.labelValues("trace")
-  private val DebugCounter = Counter.labelValues("debug")
-  private val InfoCounter = Counter.labelValues("info")
-  private val WarnCounter = Counter.labelValues("warn")
-  private val ErrorCounter = Counter.labelValues("error")
+private[logback] object InstrumentedAppender {
+
+  private[logback] final class LevelCounters(counter: PrometheusCounter) {
+    private val traceCounter = counter.labelValues("trace")
+    private val debugCounter = counter.labelValues("debug")
+    private val infoCounter = counter.labelValues("info")
+    private val warnCounter = counter.labelValues("warn")
+    private val errorCounter = counter.labelValues("error")
+
+    def inc(level: Level): Unit =
+      level match {
+        case Level.TRACE => traceCounter.inc()
+        case Level.DEBUG => debugCounter.inc()
+        case Level.INFO => infoCounter.inc()
+        case Level.WARN => warnCounter.inc()
+        case Level.ERROR => errorCounter.inc()
+        case _ => ()
+      }
+  }
+
+  private[logback] lazy val defaultCounters: Either[Throwable, LevelCounters] =
+    registerCounters(PrometheusRegistry.defaultRegistry)
+
+  private[logback] def registerCounters(registry: PrometheusRegistry): Either[Throwable, LevelCounters] =
+    try {
+      val counter = PrometheusCounter
+        .builder()
+        .name("logback_appender_total")
+        .help("Logback log statements at various log levels")
+        .labelNames("level")
+        .register(registry)
+      Right(new LevelCounters(counter))
+    } catch {
+      // never swallow JVM-fatal errors; anything else (incl. LinkageError) must not break logging
+      case cause: VirtualMachineError => throw cause
+      case cause: InterruptedException =>
+        Thread.currentThread().interrupt()
+        Left(cause)
+      case cause: Throwable => Left(cause)
+    }
+
 }

--- a/modules/logback/src/test/scala/com/evolution/smetrics/logback/InstrumentedAppenderSpec.scala
+++ b/modules/logback/src/test/scala/com/evolution/smetrics/logback/InstrumentedAppenderSpec.scala
@@ -2,8 +2,8 @@ package com.evolution.smetrics.logback
 
 import cats.effect.IO
 import cats.syntax.all.*
-import ch.qos.logback.classic.{Level, LoggerContext}
 import ch.qos.logback.classic.spi.LoggingEvent
+import ch.qos.logback.classic.{Level, LoggerContext}
 import ch.qos.logback.core.status.Status
 import io.prometheus.metrics.model.registry.{Collector, PrometheusRegistry}
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters.*
 
 object InstrumentedAppenderSpec extends SimpleIOSuite {
 
-  import InstrumentedAppender.{registerCounters, LevelCounters}
+  import InstrumentedAppender.{LevelCounters, registerCounters}
 
   test("count log events per level") {
     val levels = List(Level.TRACE, Level.DEBUG, Level.INFO, Level.INFO, Level.WARN, Level.ERROR)

--- a/modules/logback/src/test/scala/com/evolution/smetrics/logback/InstrumentedAppenderSpec.scala
+++ b/modules/logback/src/test/scala/com/evolution/smetrics/logback/InstrumentedAppenderSpec.scala
@@ -5,6 +5,7 @@ import cats.syntax.all.*
 import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.classic.{Level, LoggerContext}
 import ch.qos.logback.core.status.Status
+import com.evolution.smetrics.logback.InstrumentedAppender.{LevelCounters, registerCounters}
 import io.prometheus.metrics.model.registry.{Collector, PrometheusRegistry}
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import weaver.SimpleIOSuite
@@ -12,8 +13,6 @@ import weaver.SimpleIOSuite
 import scala.jdk.CollectionConverters.*
 
 object InstrumentedAppenderSpec extends SimpleIOSuite {
-
-  import InstrumentedAppender.{LevelCounters, registerCounters}
 
   test("count log events per level") {
     val levels = List(Level.TRACE, Level.DEBUG, Level.INFO, Level.INFO, Level.WARN, Level.ERROR)
@@ -100,15 +99,9 @@ object InstrumentedAppenderSpec extends SimpleIOSuite {
     val registry: PrometheusRegistry = new PrometheusRegistry() {
       override def register(collector: Collector): Unit = throw new OutOfMemoryError("test")
     }
-    // fatal errors must not go through the IO runtime, hence the manual try/catch
-    val rethrown =
-      try {
-        val _ = registerCounters(registry)
-        false
-      } catch {
-        case _: OutOfMemoryError => true
-      }
-    expect(rethrown)
+    // Either.catchOnly matches on the class and thus, unlike util.Try, sees fatal errors
+    val outcome = Either.catchOnly[OutOfMemoryError](registerCounters(registry))
+    expect(clue(outcome).isLeft)
   }
 
   test("share one JVM-wide registration result between appenders by default") {

--- a/modules/logback/src/test/scala/com/evolution/smetrics/logback/InstrumentedAppenderSpec.scala
+++ b/modules/logback/src/test/scala/com/evolution/smetrics/logback/InstrumentedAppenderSpec.scala
@@ -1,0 +1,147 @@
+package com.evolution.smetrics.logback
+
+import cats.effect.IO
+import cats.syntax.all.*
+import ch.qos.logback.classic.{Level, LoggerContext}
+import ch.qos.logback.classic.spi.LoggingEvent
+import ch.qos.logback.core.status.Status
+import io.prometheus.metrics.model.registry.{Collector, PrometheusRegistry}
+import io.prometheus.metrics.model.snapshots.CounterSnapshot
+import weaver.SimpleIOSuite
+
+import scala.jdk.CollectionConverters.*
+
+object InstrumentedAppenderSpec extends SimpleIOSuite {
+
+  import InstrumentedAppender.{registerCounters, LevelCounters}
+
+  test("count log events per level") {
+    val levels = List(Level.TRACE, Level.DEBUG, Level.INFO, Level.INFO, Level.WARN, Level.ERROR)
+    for {
+      registry <- IO(new PrometheusRegistry())
+      appender <- IO(appenderWith(registerCounters(registry)))
+      _ <- IO(appender.start())
+      _ <- levels.traverse_ { level => IO(appender.doAppend(event(level))) }
+      counts <- IO(levelCounts(registry))
+    } yield expect(
+      clue(counts) == Map(
+        "trace" -> 1d,
+        "debug" -> 1d,
+        "info" -> 2d,
+        "warn" -> 1d,
+        "error" -> 1d,
+      ),
+    )
+  }
+
+  test("ignore events with unmapped levels") {
+    for {
+      registry <- IO(new PrometheusRegistry())
+      appender <- IO(appenderWith(registerCounters(registry)))
+      _ <- IO(appender.start())
+      _ <- IO(appender.doAppend(event(Level.OFF)))
+      counts <- IO(levelCounts(registry))
+    } yield expect(clue(counts).values.sum == 0d)
+  }
+
+  test("share the counters between appender instances, as logback re-creates appenders on config reload") {
+    for {
+      registry <- IO(new PrometheusRegistry())
+      counters <- IO(registerCounters(registry))
+      firstAppender <- IO(appenderWith(counters))
+      secondAppender <- IO(appenderWith(counters))
+      _ <- IO(firstAppender.start())
+      _ <- IO(secondAppender.start())
+      _ <- IO(firstAppender.doAppend(event(Level.INFO)))
+      _ <- IO(secondAppender.doAppend(event(Level.INFO)))
+      counts <- IO(levelCounts(registry))
+    } yield expect(clue(counts).get("info").contains(2d))
+  }
+
+  test("return the failure instead of throwing when the counter name is already registered") {
+    for {
+      registry <- IO(new PrometheusRegistry())
+      firstAttempt <- IO(registerCounters(registry))
+      secondAttempt <- IO(registerCounters(registry))
+    } yield expect.all(
+      clue(firstAttempt).isRight,
+      clue(secondAttempt).left.exists {
+        case _: IllegalArgumentException => true
+        case _ => false
+      },
+    )
+  }
+
+  test("doAppend does not throw when the counter registration failed") {
+    val levels = List(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR)
+    for {
+      appender <- IO(appenderWith(failedRegistration()))
+      _ <- IO(appender.setContext(new LoggerContext()))
+      _ <- IO(appender.start())
+      _ <- levels.traverse_ { level => IO(appender.doAppend(event(level))) }
+    } yield expect(clue(appender.isStarted))
+  }
+
+  test("report the registration failure to the logback status system on start") {
+    for {
+      appender <- IO(appenderWith(failedRegistration()))
+      loggerContext <- IO(new LoggerContext())
+      _ <- IO(appender.setContext(loggerContext))
+      _ <- IO(appender.start())
+      statuses <- IO(loggerContext.getStatusManager.getCopyOfStatusList.asScala.toList)
+    } yield expect(
+      clue(statuses.map { status => (status.getLevel, status.getMessage) }).exists { case (level, message) =>
+        level == Status.ERROR && message.contains("logback_appender_total")
+      },
+    )
+  }
+
+  pureTest("registerCounters rethrows JVM-fatal errors") {
+    val registry: PrometheusRegistry = new PrometheusRegistry() {
+      override def register(collector: Collector): Unit = throw new OutOfMemoryError("test")
+    }
+    // fatal errors must not go through the IO runtime, hence the manual try/catch
+    val rethrown =
+      try {
+        val _ = registerCounters(registry)
+        false
+      } catch {
+        case _: OutOfMemoryError => true
+      }
+    expect(rethrown)
+  }
+
+  test("share one JVM-wide registration result between appenders by default") {
+    for {
+      firstAppender <- IO(new InstrumentedAppender())
+      secondAppender <- IO(new InstrumentedAppender())
+    } yield expect(firstAppender.counters eq secondAppender.counters)
+  }
+
+  private def appenderWith(resolvedCounters: Either[Throwable, LevelCounters]): InstrumentedAppender =
+    new InstrumentedAppender {
+      override private[logback] def counters: Either[Throwable, LevelCounters] = resolvedCounters
+    }
+
+  private def failedRegistration(): Either[Throwable, LevelCounters] = {
+    val registry = new PrometheusRegistry()
+    val _ = registerCounters(registry)
+    registerCounters(registry)
+  }
+
+  private def event(level: Level): LoggingEvent = {
+    val loggingEvent = new LoggingEvent()
+    loggingEvent.setLevel(level)
+    loggingEvent
+  }
+
+  private def levelCounts(registry: PrometheusRegistry): Map[String, Double] =
+    registry
+      .scrape()
+      .asScala
+      .collect { case counterSnapshot: CounterSnapshot => counterSnapshot }
+      .flatMap { counterSnapshot => counterSnapshot.getDataPoints.asScala }
+      .map { dataPoint => dataPoint.getLabels.get("level") -> dataPoint.getValue }
+      .toMap
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   val prometheus = "io.prometheus" % "simpleclient" % prometheusVersion
   val prometheusCommon = "io.prometheus" % "simpleclient_common" % prometheusVersion
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.20"
+  val weaver = "org.typelevel" %% "weaver-cats" % "0.13.0"
   val `cats-helper` = "com.evolutiongaming" %% "cats-helper" % "3.12.2"
   val http4s = "org.http4s" %% "http4s-core" % "0.23.36"
   val doobie = "org.typelevel" %% "doobie-core" % "1.0.0-RC13"


### PR DESCRIPTION
InstrumentedAppender registers its counters in a static initializer against the Prometheus default registry. If that registration throws, the first log event fails with ExceptionInInitializerError and every log event after it throws NoClassDefFoundError — permanently. Logback's doAppend catches only Exception, so these Errors escape the appender chain and propagate out of logger.info(...) into application code. A metrics problem becomes an application problem.

- Registration failure is now a value: registerCounters(registry) returns Either[Throwable, LevelCounters], so class init can never throw.
- The catch is explicitly wider than NonFatal: NonFatal excludes LinkageError, which is one of the failure modes this must contain. Only VirtualMachineError is rethrown. InterruptedException degrades too, with the interrupt flag restored.
- append is a no-op when registration failed, start() reports the cause once through the logback status system (addError), so the failure is visible instead of silent.
- Counters are still registered once per JVM: logback re-creates appender instances on every scan reload, so per-instance registration would either hit duplicate-name errors or reset the time series on each reload.
- Public API is unchanged, all new members are package-private. Binary compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus counter registration to prevent duplicate registrations across appenders.
  * Appenders now handle registration failures safely, report errors through Logback status messages, and avoid emitting metrics when unavailable.
  * Preserved fatal error propagation and thread interruption behavior.

* **Tests**
  * Added coverage for log-level counting, shared counters, registration failures, unmapped levels, and default registry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->