### PR TITLE
make `write004` safer

### DIFF
--- a/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
+++ b/modules/prometheus/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
@@ -21,7 +21,7 @@ object Prometheus { prometheus =>
 
       override val registry: CollectorRegistry[F] = CollectorRegistryPrometheus(collectorRegistry)
 
-      override val write004: F[String] = Sync[F].delay {
+      override val write004: F[String] = Sync[F].blocking {
         val writer = new StringWriter
         TextFormat.write004(writer, collectorRegistry.metricFamilySamples)
         writer.toString

--- a/modules/prometheus_v1/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
+++ b/modules/prometheus_v1/src/main/scala/com/evolutiongaming/smetrics/Prometheus.scala
@@ -6,6 +6,7 @@ import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 
 import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
 
 trait Prometheus[F[_]] {
 
@@ -21,11 +22,11 @@ object Prometheus { prometheus =>
 
       override val registry: CollectorRegistry[F] = CollectorRegistryPrometheus(collectorRegistry)
 
-      override val write004: F[String] = Sync[F].delay {
+      override val write004: F[String] = Sync[F].blocking {
         val out = new ByteArrayOutputStream()
         val textFormatWriter = PrometheusTextFormatWriter.builder().setIncludeCreatedTimestamps(false).build()
         textFormatWriter.write(out, collectorRegistry.scrape())
-        out.toString("UTF-8")
+        out.toString(StandardCharsets.UTF_8)
       }
     }
 


### PR DESCRIPTION
Change the effect wrapping from `.delay` to `.blocking` as scraping of metrics **might** include blocking call(s). 

For example the downstream user might add own metric which reads file on `.collect`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of Prometheus metric output generation by running serialization in a blocking-safe context.
  * Standardized metric text encoding to UTF-8 for consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->